### PR TITLE
lodash/import-scope is added to udemy-website

### DIFF
--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -10,6 +10,7 @@ module.exports = {
     plugins: [
         'udemy',
         'filenames',
+        'lodash',
         'underscore',
     ],
     settings: {
@@ -21,6 +22,7 @@ module.exports = {
     },
     rules: {
         'filenames/match-regex': ['error', '^(?:[a-z0-9\\-]+(?:\\.(?:jqui-widget|ng-(?:constant|controller|directive|factory|filter|provider|service)|react-(?:component|proptypes)|mobx-(?:model|store)))?(?:\\.spec)?)$'],
+        'lodash/import-scope': ['error', 'method'],
         'udemy/angular-path-based-module-names': ['error', 'src/udemy/js'],
         'underscore/prefer-noop': ['error', 'always'],
     },

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -21,6 +21,7 @@
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-lodash": "^2.5.0",
     "eslint-plugin-underscore": "^0.0.10"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,12 @@ eslint-plugin-jsx-a11y@^6.0.2:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^1.4.0"
 
+eslint-plugin-lodash@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-2.5.0.tgz#be23eb0c0b7b15c1fc3a46bf702b4be757446b45"
+  dependencies:
+    lodash "~4.17.0"
+
 eslint-plugin-promise@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
@@ -1869,7 +1875,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
##### *To:*
@cansin 
/cc @udemy/team-f 

##### *What:*
This rule will prevent importing the whole lodash library accidentally which increases the bundle sizes. We will only allow importing individual functions.
e.g. `import map from 'lodash/map'`

More info about the specific rule we're enabling: https://github.com/wix/eslint-plugin-lodash/blob/HEAD/docs/rules/import-scope.md

##### *Trello:*
https://trello.com/c/IEjsTHSk/1725-remove-lodash-from-app-bundles

##### *What did you test:*
Tested the thing by manually changing the eslintrc file on website-django repo.
