### PR TITLE
Add pgettext to list of acceptable global variables

### DIFF
--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.0.2"></a>
+## [4.0.2](https://github.com/udemy/eslint-udemy/compare/eslint-config-udemy-website@4.0.1...eslint-config-udemy-website@4.0.2) (2017-12-18)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
 <a name="4.0.1"></a>
 ## [4.0.1](https://github.com/udemy/eslint-udemy/compare/eslint-config-udemy-website@4.0.0...eslint-config-udemy-website@4.0.1) (2017-12-07)
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -44,6 +44,7 @@ module.exports = {
         angular: false,
         gettext: false,
         ngettext: false,
+        pgettext: false,
         interpolate: false,
         ninterpolate: false,
     },

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@udemy/team-f @udemy/team-t

##### *What:*
We need to be able to add comments for translators from React components, e.g. `pgettext('Keyboard shift key', 'Shift')`. Currently the use of `pgettext` is failing linting rule `no-undef`.