### PR TITLE
Enable curly bracket spacing for jsx-curly-spacing children

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.6.3"></a>
+## [0.6.3](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.2...babel-polyfill-udemy-website@0.6.3) (2018-02-21)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
 <a name="0.6.2"></a>
 ## [0.6.2](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.1...babel-polyfill-udemy-website@0.6.2) (2018-02-07)
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^3.1.16",
-    "eslint-config-udemy-website": "^4.0.4"
+    "eslint-config-udemy-website": "^4.0.5"
   },
   "dependencies": {
     "babel-cli": "6.18.0",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.6.3"></a>
+## [0.6.3](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.6.2...babel-preset-udemy-website@0.6.3) (2018-02-21)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
 <a name="0.6.2"></a>
 ## [0.6.2](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.6.1...babel-preset-udemy-website@0.6.2) (2018-02-07)
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^3.1.16",
-    "eslint-config-udemy-website": "^4.0.4"
+    "eslint-config-udemy-website": "^4.0.5"
   },
   "dependencies": {
     "babel-plugin-check-es2015-constants": "6.8.0",

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.11"></a>
+## [3.1.11](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@3.1.10...eslint-config-udemy-react-addons@3.1.11) (2018-02-21)
+
+
+### Bug Fixes
+
+* Enable children curly bracket spacing attribute for jsx-curly-spacing rule. ([cb61a10](https://github.com/udemy/js-tooling/commit/cb61a10))
+
+
+
+
 <a name="3.1.10"></a>
 ## [3.1.10](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@3.1.9...eslint-config-udemy-react-addons@3.1.10) (2018-02-07)
 

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-react-addons/parts/react.js
+++ b/packages/eslint-config-udemy-react-addons/parts/react.js
@@ -8,7 +8,7 @@ module.exports = {
         // enforce boolean attributes notation in JSX
         'react/jsx-boolean-value': ['error', 'never'],
         // enforce or disallow spaces inside of curly braces in JSX attributes
-        'react/jsx-curly-spacing': ['error', 'always', { allowMultiline: true }],
+        'react/jsx-curly-spacing': ['error', { when: 'always', children: true }],
         // prevent usage of .bind() in JSX props
         'react/jsx-no-bind': ['error', { ignoreRefs: true, allowArrowFunctions: false, allowBind: false }],
         // prevent duplicate props in JSX

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.0.5"></a>
+## [4.0.5](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.0.4...eslint-config-udemy-website@4.0.5) (2018-02-21)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
 <a name="4.0.4"></a>
 ## [4.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.0.3...eslint-config-udemy-website@4.0.4) (2018-02-07)
 

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -17,7 +17,7 @@
     "eslint-config-udemy-babel-addons": "^1.0.9",
     "eslint-config-udemy-basics": "^3.1.16",
     "eslint-config-udemy-jasmine-addons": "^3.1.10",
-    "eslint-config-udemy-react-addons": "^3.1.10",
+    "eslint-config-udemy-react-addons": "^3.1.11",
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.8.0",


### PR DESCRIPTION
##### *To:*
@cansin 

##### *What:*
Add curly brace spacing for jsx children as per here (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md)

##### *Trello:*
https://trello.com/c/xRAx7WGU/1841-tweak-eslint-to-put-space-inside-curly-for-children

##### *What did you test:*
Ensure unit tests are passing.
From website-django repo, run `yarn run lint` ~1300 errors from new rule.
Run `yarn run lint-fix` and ensure most errors are fixed - `git diff -w origin/master` should not show any diffs for files that were autofixed.

##### *What dashboards will you be monitoring:*
Standard
