### PR TITLE
Add jsx-no-literals in warning mode

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.6.6"></a>
+## [0.6.6](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.5...babel-polyfill-udemy-website@0.6.6) (2018-04-30)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
 <a name="0.6.5"></a>
 ## [0.6.5](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.4...babel-polyfill-udemy-website@0.6.5) (2018-04-24)
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^3.1.18",
-    "eslint-config-udemy-website": "^4.1.1"
+    "eslint-config-udemy-website": "^4.1.2"
   },
   "dependencies": {
     "babel-cli": "6.18.0",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.8.1"></a>
+## [0.8.1](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.8.0...babel-preset-udemy-website@0.8.1) (2018-04-30)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
 <a name="0.8.0"></a>
 # [0.8.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.7.0...babel-preset-udemy-website@0.8.0) (2018-04-27)
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^3.1.18",
-    "eslint-config-udemy-website": "^4.1.1"
+    "eslint-config-udemy-website": "^4.1.2"
   },
   "dependencies": {
     "babel-plugin-check-es2015-constants": "6.8.0",

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.2.0"></a>
+# [3.2.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@3.1.11...eslint-config-udemy-react-addons@3.2.0) (2018-04-30)
+
+
+### Features
+
+* Introduce jsx-no-literals ([86c2b5c](https://github.com/udemy/js-tooling/commit/86c2b5c))
+
+
+
+
 <a name="3.1.11"></a>
 ## [3.1.11](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@3.1.10...eslint-config-udemy-react-addons@3.1.11) (2018-02-21)
 

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "3.1.11",
+  "version": "3.2.0",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-react-addons/parts/react.js
+++ b/packages/eslint-config-udemy-react-addons/parts/react.js
@@ -13,6 +13,8 @@ module.exports = {
         'react/jsx-no-bind': ['error', { ignoreRefs: true, allowArrowFunctions: false, allowBind: false }],
         // prevent duplicate props in JSX
         'react/jsx-no-duplicate-props': ['error', { ignoreCase: false }],
+        // enforce l10n wrapping of strings literals
+        'react/jsx-no-literals': 'error',
         // disallow undeclared variables in JSX
         'react/jsx-no-undef': 'error',
         // enforce PascalCase for user-defined JSX components

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.2"></a>
+## [4.1.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.1.1...eslint-config-udemy-website@4.1.2) (2018-04-30)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
 <a name="4.1.1"></a>
 ## [4.1.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.1.0...eslint-config-udemy-website@4.1.1) (2018-04-24)
 

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -17,7 +17,7 @@
     "eslint-config-udemy-babel-addons": "^1.0.9",
     "eslint-config-udemy-basics": "^3.1.18",
     "eslint-config-udemy-jasmine-addons": "^3.1.10",
-    "eslint-config-udemy-react-addons": "^3.1.11",
+    "eslint-config-udemy-react-addons": "^3.2.0",
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.8.0",


### PR DESCRIPTION
@udemy/team-f can you advise on the right steps sequence for this.. I presume merging and publishing here won't affect anything until we upgrade this package in website-django.. then again thinking of adding as warning first anyway, skipping the rule on certain paths when adding it (e.g. tests, examples) and then having people fix their code before upgrading to error status. wdyt?

PS. Checked Inanc's comment and yea, just going with the popular version for now until it becomes clear that we need to adjust it.