### PR TITLE
feat: Introduce udemy/import-blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ there are three important commands to know:
     ```
     $ `yarn bin`/lerna add eslint-plugin-lodash --scope=eslint-config-udemy-website
     ``` 
+
+* **[`lerna remove` is not implemented yet](https://github.com/lerna/lerna/issues/833#issuecomment-375850356):** In order to remove a dependency from an existing package's `package.json` file, for now you'd run `` `cd packages/package-name; yarn remove dependency-name` ``. E.g.:
+
+    ```
+    $ cd packages/eslint-config-udemy-website
+    $ yarn remove eslint-plugin-lodash
+    ``` 
     
 * **[`lerna bootstrap`](https://github.com/lerna/lerna#bootstrap):** In order to install all of the dependencies
 for every package, you can simply run `` `yarn bin`/lerna bootstrap``.

--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.6.4"></a>
+## [0.6.4](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.3...babel-polyfill-udemy-website@0.6.4) (2018-04-23)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
 <a name="0.6.3"></a>
 ## [0.6.3](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.2...babel-polyfill-udemy-website@0.6.3) (2018-02-21)
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.16",
-    "eslint-config-udemy-website": "^4.0.5"
+    "eslint-config-udemy-basics": "^3.1.17",
+    "eslint-config-udemy-website": "^4.1.0"
   },
   "dependencies": {
     "babel-cli": "6.18.0",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.6.4"></a>
+## [0.6.4](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.6.3...babel-preset-udemy-website@0.6.4) (2018-04-23)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
 <a name="0.6.3"></a>
 ## [0.6.3](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.6.2...babel-preset-udemy-website@0.6.3) (2018-02-21)
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.16",
-    "eslint-config-udemy-website": "^4.0.5"
+    "eslint-config-udemy-basics": "^3.1.17",
+    "eslint-config-udemy-website": "^4.1.0"
   },
   "dependencies": {
     "babel-plugin-check-es2015-constants": "6.8.0",

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.17"></a>
+## [3.1.17](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.16...eslint-config-udemy-basics@3.1.17) (2018-04-23)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
 <a name="3.1.16"></a>
 ## [3.1.16](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.15...eslint-config-udemy-basics@3.1.16) (2018-02-07)
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-udemy": "^4.0.3"
+    "eslint-plugin-udemy": "^4.1.0"
   },
   "peerDependencies": {
     "babel-eslint": "^8.0.2",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.0"></a>
+# [4.1.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.0.5...eslint-config-udemy-website@4.1.0) (2018-04-23)
+
+
+### Features
+
+* Introduce udemy/import-blacklist ([3e922cd](https://github.com/udemy/js-tooling/commit/3e922cd))
+
+
+
+
 <a name="4.0.5"></a>
 ## [4.0.5](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.0.4...eslint-config-udemy-website@4.0.5) (2018-02-21)
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -10,7 +10,6 @@ module.exports = {
     plugins: [
         'udemy',
         'filenames',
-        'lodash',
         'underscore',
     ],
     settings: {
@@ -21,9 +20,9 @@ module.exports = {
         },
     },
     rules: {
-        'filenames/match-regex': ['error', '^(?:[a-z0-9\\-]+(?:\\.(?:jqui-widget|ng-(?:constant|controller|directive|factory|filter|provider|service)|react-(?:component|proptypes)|mobx-(?:model|store)))?(?:\\.spec)?)$'],
-        'lodash/import-scope': ['error', 'method'],
+        'filenames/match-regex': ['error', '^(?:[a-z0-9\\-]+(?:\\.(?:ng-(?:constant|controller|directive|factory|filter|provider|service)|react-(?:component|proptypes)|mobx-(?:model|store)))?(?:\\.spec)?)$'],
         'udemy/angular-path-based-module-names': ['error', 'always'],
+        'udemy/import-blacklist': ['error'],
         'underscore/prefer-noop': ['error', 'always'],
     },
     overrides: [

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -22,7 +22,52 @@ module.exports = {
     rules: {
         'filenames/match-regex': ['error', '^(?:[a-z0-9\\-]+(?:\\.(?:ng-(?:constant|controller|directive|factory|filter|provider|service)|react-(?:component|proptypes)|mobx-(?:model|store)))?(?:\\.spec)?)$'],
         'udemy/angular-path-based-module-names': ['error', 'always'],
-        'udemy/import-blacklist': ['error'],
+        'udemy/import-blacklist': ['error', [
+            {
+                // For correct configuration
+                pattern: '^currencyformatter(?:\\.js)?$',
+                message: 'Please import from utils/currency-formatter/, not from currencyformatter',
+                exceptions: ['utils/currency-formatter(?:\\.spec)?\\.js$'],
+            },
+            {
+                // For improved JS bundling
+                pattern: '^lodash(?:\\.js)?$',
+                message: 'Please import from e.g. lodash/foo, not from lodash directly',
+            },
+            {
+                // For code consistency
+                pattern: '^mobx/lib/mobx(?:\\.js)?$',
+                message: 'Please import from mobx, not from mobx/lib/mobx',
+            },
+            {
+                // For correct configuration
+                pattern: '^moment(?:\\.js)?$',
+                message: 'Please import from utils/ud-moment, not from moment',
+                exceptions: ['utils/ud-moment(?:\\.spec)?\\.js$'],
+            },
+            {
+                // For correct configuration
+                pattern: '^numeral(?:\\.js)?$',
+                message: 'Please import from utils/ud-numeral, not from numeral',
+                exceptions: ['utils/ud-numeral(?:\\.spec)?\\.js$'],
+            },
+            {
+                // For improved JS bundling
+                pattern: '^react-bootstrap(?:\\.js)?$',
+                message: 'Please import from e.g. react-bootstrap/lib/foo, not from react-bootstrap directly',
+            },
+            {
+                // For correct implementation
+                pattern: '^react-bootstrap.*?$',
+                message: 'Please import from base-components/, not from react-bootstrap/',
+                exceptions: ['/base-components/'],
+            },
+            {
+                // For improved JS bundling
+                pattern: '^react-overlays(?:\\.js)?$',
+                message: 'Please import from e.g. react-overlays/lib/foo, not from react-overlays directly',
+            },
+        ]],
         'underscore/prefer-noop': ['error', 'always'],
     },
     overrides: [

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -21,7 +21,6 @@
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-lodash": "^2.5.0",
     "eslint-plugin-underscore": "^0.0.10"
   },
   "peerDependencies": {

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "eslint-config-udemy-babel-addons": "^1.0.9",
-    "eslint-config-udemy-basics": "^3.1.16",
+    "eslint-config-udemy-basics": "^3.1.17",
     "eslint-config-udemy-jasmine-addons": "^3.1.10",
     "eslint-config-udemy-react-addons": "^3.1.11",
     "eslint-import-resolver-webpack": "^0.8.3",

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.0"></a>
+# [4.1.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.0.3...eslint-plugin-udemy@4.1.0) (2018-04-23)
+
+
+### Features
+
+* Introduce udemy/import-blacklist ([3e922cd](https://github.com/udemy/js-tooling/commit/3e922cd))
+
+
+
+
 <a name="4.0.3"></a>
 ## [4.0.3](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.0.2...eslint-plugin-udemy@4.0.3) (2018-02-07)
 

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
@@ -1,6 +1,6 @@
 # Import Blacklist
 
-`udemy/import-blacklist` blacklists certain imports in JS files. For example, it might tell you to `please import from foo/lib/, not from foo directly`. There are several reasons we enforce this rule:
+`udemy/import-blacklist` blacklists certain imports in JS files. For example, it might tell you to `please import from e.g. foo/lib/bar, not from foo directly`. There are several reasons we enforce this rule:
 
 - Sometimes, a more specific import, e.g. `import bar from 'foo/lib/bar';`, can significantly reduce JS bundle size compared to e.g. `import { bar } from 'foo';`, since `'foo'` may contain many modules that the importing file is not actually using.
 - Some libraries have Udemy-specific wrappers that configure or extend the original library, in which case the library will only work properly if it is imported via the wrapper.
@@ -13,12 +13,12 @@ The blacklist is configured by a list of regexes. You may optionally specify a l
 Assuming the following configuration:
 
 ```js
-const blacklist = [
+'udemy/import-blacklist': ['error', [
     {
         pattern: '^foo(?:\\.js)?$',
         message: 'Please import from foo/lib/, not from foo',
     },
-];
+]]
 ```
 
 The following imports would error:

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
@@ -1,0 +1,50 @@
+# Import Blacklist
+
+`udemy/import-blacklist` blacklists certain imports in JS files. For example, it might tell you to `please import from foo/lib/, not from foo directly`. There are several reasons we enforce this rule:
+
+- Sometimes, a more specific import, e.g. `import bar from 'foo/lib/bar';`, can significantly reduce JS bundle size compared to e.g. `import { bar } from 'foo';`, since `'foo'` may contain many modules that the importing file is not actually using.
+- Some libraries have Udemy-specific wrappers that configure or extend the original library, in which case the library will only work properly if it is imported via the wrapper.
+- For code consistency, we may prefer one syntax over another. For example, if "main" in package.json points to `'foo/lib/foo'`, we may prefer `import foo from 'foo';` over `import foo from 'foo/lib/foo';`.
+
+## Rule details
+
+The blacklist is configured by a list of regexes. You may optionally specify a list of exception regexes to whitelist certain files from the blacklist.
+
+Assuming the following configuration:
+
+```js
+const blacklist = [
+    {
+        pattern: '^foo(?:\\.js)?$',
+        message: 'Please import from foo/lib/, not from foo',
+    },
+];
+```
+
+The following imports would error:
+
+```js 
+import foo from 'foo';
+
+import foo from 'foo.js';
+
+import 'foo';
+
+import { foo } from 'foo';
+```
+
+The following imports would not error:
+
+```js
+import foo from 'foo/lib/foo';
+
+import foo from 'foo.less';
+```
+
+If we added:
+
+```js
+exceptions: ['bar\\.js'],
+```
+
+then none of the imports in some-path/bar.js would error.

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/index.js
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/index.js
@@ -1,55 +1,32 @@
 'use strict';
 
-const blacklist = [
-    {
-        // For correct configuration
-        pattern: '^currencyformatter(?:\\.js)?$',
-        message: 'Please import from utils/currency-formatter/, not from currencyformatter',
-        exceptions: ['utils/currency-formatter(?:\\.spec)?\\.js$'],
-    },
-    {
-        // For improved JS bundling
-        pattern: '^lodash(?:\\.js)?$',
-        message: 'Please import from lodash/lib/, not from lodash directly',
-    },
-    {
-        // For code consistency
-        pattern: '^mobx/lib/mobx(?:\\.js)?$',
-        message: 'Please import from mobx, not from mobx/lib/mobx',
-    },
-    {
-        // For correct configuration
-        pattern: '^moment(?:\\.js)?$',
-        message: 'Please import from utils/ud-moment, not from moment',
-        exceptions: ['utils/ud-moment(?:\\.spec)?\\.js$'],
-    },
-    {
-        // For correct configuration
-        pattern: '^numeral(?:\\.js)?$',
-        message: 'Please import from utils/ud-numeral, not from numeral',
-        exceptions: ['utils/ud-numeral(?:\\.spec)?\\.js$'],
-    },
-    {
-        // For improved JS bundling
-        pattern: '^react-bootstrap(?:\\.js)?$',
-        message: 'Please import from react-bootstrap/lib/, not from react-bootstrap directly',
-    },
-    {
-        // For correct implementation
-        pattern: '^react-bootstrap.*?$',
-        message: 'Please import from base-components/, not from react-bootstrap/',
-        exceptions: ['/base-components/'],
-    },
-    {
-        // For improved JS bundling
-        pattern: '^react-overlays(?:\\.js)?$',
-        message: 'Please import from react-overlays/lib/, not from react-overlays directly',
-    },
-];
-
 module.exports.rules = {
     'import-blacklist': {
+        meta: {
+            schema: [{
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        pattern: {
+                            type: 'string',
+                        },
+                        message: {
+                            type: 'string',
+                        },
+                        exceptions: {
+                            type: 'array',
+                            items: {
+                                type: 'string',
+                            },
+                        },
+                    },
+                    required: ['pattern', 'message'],
+                },
+            }],
+        },
         create: function create(context) {
+            const blacklist = context.options[0] || [];
             const filename = context.getFilename();
 
             return {

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/index.js
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/index.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const blacklist = [
+    {
+        // For correct configuration
+        pattern: '^currencyformatter(?:\\.js)?$',
+        message: 'Please import from utils/currency-formatter/, not from currencyformatter',
+        exceptions: ['utils/currency-formatter(?:\\.spec)?\\.js$'],
+    },
+    {
+        // For improved JS bundling
+        pattern: '^lodash(?:\\.js)?$',
+        message: 'Please import from lodash/lib/, not from lodash directly',
+    },
+    {
+        // For code consistency
+        pattern: '^mobx/lib/mobx(?:\\.js)?$',
+        message: 'Please import from mobx, not from mobx/lib/mobx',
+    },
+    {
+        // For correct configuration
+        pattern: '^moment(?:\\.js)?$',
+        message: 'Please import from utils/ud-moment, not from moment',
+        exceptions: ['utils/ud-moment(?:\\.spec)?\\.js$'],
+    },
+    {
+        // For correct configuration
+        pattern: '^numeral(?:\\.js)?$',
+        message: 'Please import from utils/ud-numeral, not from numeral',
+        exceptions: ['utils/ud-numeral(?:\\.spec)?\\.js$'],
+    },
+    {
+        // For improved JS bundling
+        pattern: '^react-bootstrap(?:\\.js)?$',
+        message: 'Please import from react-bootstrap/lib/, not from react-bootstrap directly',
+    },
+    {
+        // For correct implementation
+        pattern: '^react-bootstrap.*?$',
+        message: 'Please import from base-components/, not from react-bootstrap/',
+        exceptions: ['/base-components/'],
+    },
+    {
+        // For improved JS bundling
+        pattern: '^react-overlays(?:\\.js)?$',
+        message: 'Please import from react-overlays/lib/, not from react-overlays directly',
+    },
+];
+
+module.exports.rules = {
+    'import-blacklist': {
+        create: function create(context) {
+            const filename = context.getFilename();
+
+            return {
+                ImportDeclaration: function ImportDeclaration(node) {
+                    blacklist.forEach(rule => {
+                        const isException = (rule.exceptions || []).some(pattern => {
+                            return new RegExp(pattern).test(filename);
+                        });
+                        if (isException) {
+                            return;
+                        }
+                        const isBlacklisted = new RegExp(rule.pattern).test(node.source.value);
+                        if (isBlacklisted) {
+                            context.report({ node, message: rule.message });
+                        }
+                    });
+                },
+            };
+        },
+    },
+};

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const path = require('path');
+const rule = require('./index').rules['import-blacklist'];
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2015,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('import-blacklist', rule, {
+    valid: [
+        {
+            code: "import currencyFormatter from 'currencyformatter.js';",
+            filename: path.join(__dirname, 'utils/currency-formatter.js'),
+        },
+        {
+            code: "import example from 'lodash/example';",
+            filename: path.join(__dirname, 'example.js'),
+        },
+        {
+            code: "import mobx from 'mobx';",
+            filename: path.join(__dirname, 'example.mobx-store.js'),
+        },
+        {
+            code: "import moment from 'moment';",
+            filename: path.join(__dirname, 'utils/ud-moment.js'),
+        },
+        {
+            code: "import numeral from 'numeral';",
+            filename: path.join(__dirname, 'utils/ud-numeral.js'),
+        },
+        {
+            code: "import Example from 'react-bootstrap/lib/Example';",
+            filename: path.join(__dirname, 'base-components/example.react-component.js'),
+        },
+        {
+            code: "import { Example } from 'react-overlays/lib/Example';",
+            filename: path.join(__dirname, 'example.react-component.js'),
+        },
+    ],
+    invalid: [
+        {
+            code: "import currencyFormatter from 'currencyformatter.js';",
+            errors: [{ message: 'Please import from utils/currency-formatter/, not from currencyformatter' }],
+            filename: path.join(__dirname, 'example.js'),
+        },
+        {
+            code: "import { example } from 'lodash';",
+            errors: [{ message: 'Please import from lodash/lib/, not from lodash directly' }],
+            filename: path.join(__dirname, 'example.js'),
+        },
+        {
+            code: "import mobx from 'mobx/lib/mobx';",
+            errors: [{ message: 'Please import from mobx, not from mobx/lib/mobx' }],
+            filename: path.join(__dirname, 'example.mobx-store.js'),
+        },
+        {
+            code: "import moment from 'moment';",
+            errors: [{ message: 'Please import from utils/ud-moment, not from moment' }],
+            filename: path.join(__dirname, 'example.js'),
+        },
+        {
+            code: "import numeral from 'numeral';",
+            errors: [{ message: 'Please import from utils/ud-numeral, not from numeral' }],
+            filename: path.join(__dirname, 'example.js'),
+        },
+        {
+            code: "import { Example } from 'react-bootstrap';",
+            errors: [{ message: 'Please import from react-bootstrap/lib/, not from react-bootstrap directly' }],
+            filename: path.join(__dirname, 'base-components/example.react-component.js'),
+        },
+        {
+            code: "import Example from 'react-bootstrap/lib/Example';",
+            errors: [{ message: 'Please import from base-components/, not from react-bootstrap/' }],
+            filename: path.join(__dirname, 'example.react-component.js'),
+        },
+        {
+            code: "import { Example } from 'react-overlays';",
+            errors: [{ message: 'Please import from react-overlays/lib/, not from react-overlays directly' }],
+            filename: path.join(__dirname, 'example.react-component.js'),
+        },
+    ],
+});

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
@@ -11,35 +11,89 @@ const ruleTester = new RuleTester({
     },
 });
 
+const options = [[
+    {
+        // For correct configuration
+        pattern: '^currencyformatter(?:\\.js)?$',
+        message: 'Please import from utils/currency-formatter/, not from currencyformatter',
+        exceptions: ['utils/currency-formatter(?:\\.spec)?\\.js$'],
+    },
+    {
+        // For improved JS bundling
+        pattern: '^lodash(?:\\.js)?$',
+        message: 'Please import from e.g. lodash/foo, not from lodash directly',
+    },
+    {
+        // For code consistency
+        pattern: '^mobx/lib/mobx(?:\\.js)?$',
+        message: 'Please import from mobx, not from mobx/lib/mobx',
+    },
+    {
+        // For correct configuration
+        pattern: '^moment(?:\\.js)?$',
+        message: 'Please import from utils/ud-moment, not from moment',
+        exceptions: ['utils/ud-moment(?:\\.spec)?\\.js$'],
+    },
+    {
+        // For correct configuration
+        pattern: '^numeral(?:\\.js)?$',
+        message: 'Please import from utils/ud-numeral, not from numeral',
+        exceptions: ['utils/ud-numeral(?:\\.spec)?\\.js$'],
+    },
+    {
+        // For improved JS bundling
+        pattern: '^react-bootstrap(?:\\.js)?$',
+        message: 'Please import from e.g. react-bootstrap/lib/foo, not from react-bootstrap directly',
+    },
+    {
+        // For correct implementation
+        pattern: '^react-bootstrap.*?$',
+        message: 'Please import from base-components/, not from react-bootstrap/',
+        exceptions: ['/base-components/'],
+    },
+    {
+        // For improved JS bundling
+        pattern: '^react-overlays(?:\\.js)?$',
+        message: 'Please import from e.g. react-overlays/lib/foo, not from react-overlays directly',
+    },
+]];
+
 ruleTester.run('import-blacklist', rule, {
     valid: [
         {
             code: "import currencyFormatter from 'currencyformatter.js';",
             filename: path.join(__dirname, 'utils/currency-formatter.js'),
+            options,
         },
         {
             code: "import example from 'lodash/example';",
             filename: path.join(__dirname, 'example.js'),
+            options,
         },
         {
             code: "import mobx from 'mobx';",
             filename: path.join(__dirname, 'example.mobx-store.js'),
+            options,
         },
         {
             code: "import moment from 'moment';",
             filename: path.join(__dirname, 'utils/ud-moment.js'),
+            options,
         },
         {
             code: "import numeral from 'numeral';",
             filename: path.join(__dirname, 'utils/ud-numeral.js'),
+            options,
         },
         {
             code: "import Example from 'react-bootstrap/lib/Example';",
             filename: path.join(__dirname, 'base-components/example.react-component.js'),
+            options,
         },
         {
             code: "import { Example } from 'react-overlays/lib/Example';",
             filename: path.join(__dirname, 'example.react-component.js'),
+            options,
         },
     ],
     invalid: [
@@ -47,41 +101,49 @@ ruleTester.run('import-blacklist', rule, {
             code: "import currencyFormatter from 'currencyformatter.js';",
             errors: [{ message: 'Please import from utils/currency-formatter/, not from currencyformatter' }],
             filename: path.join(__dirname, 'example.js'),
+            options,
         },
         {
             code: "import { example } from 'lodash';",
-            errors: [{ message: 'Please import from lodash/lib/, not from lodash directly' }],
+            errors: [{ message: 'Please import from e.g. lodash/foo, not from lodash directly' }],
             filename: path.join(__dirname, 'example.js'),
+            options,
         },
         {
             code: "import mobx from 'mobx/lib/mobx';",
             errors: [{ message: 'Please import from mobx, not from mobx/lib/mobx' }],
             filename: path.join(__dirname, 'example.mobx-store.js'),
+            options,
         },
         {
             code: "import moment from 'moment';",
             errors: [{ message: 'Please import from utils/ud-moment, not from moment' }],
             filename: path.join(__dirname, 'example.js'),
+            options,
         },
         {
             code: "import numeral from 'numeral';",
             errors: [{ message: 'Please import from utils/ud-numeral, not from numeral' }],
             filename: path.join(__dirname, 'example.js'),
+            options,
         },
         {
             code: "import { Example } from 'react-bootstrap';",
-            errors: [{ message: 'Please import from react-bootstrap/lib/, not from react-bootstrap directly' }],
+            errors: [{ message: 'Please import from e.g. react-bootstrap/lib/foo, not from react-bootstrap directly' }],
             filename: path.join(__dirname, 'base-components/example.react-component.js'),
+            options,
         },
         {
             code: "import Example from 'react-bootstrap/lib/Example';",
             errors: [{ message: 'Please import from base-components/, not from react-bootstrap/' }],
             filename: path.join(__dirname, 'example.react-component.js'),
+            options,
         },
         {
             code: "import { Example } from 'react-overlays';",
-            errors: [{ message: 'Please import from react-overlays/lib/, not from react-overlays directly' }],
+            errors: [{ message: 'Please import from e.g. react-overlays/lib/foo, not from react-overlays directly' }],
             filename: path.join(__dirname, 'example.react-component.js'),
+            options,
         },
     ],
 });

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
@@ -13,136 +13,77 @@ const ruleTester = new RuleTester({
 
 const options = [[
     {
-        // For correct configuration
-        pattern: '^currencyformatter(?:\\.js)?$',
-        message: 'Please import from utils/currency-formatter/, not from currencyformatter',
-        exceptions: ['utils/currency-formatter(?:\\.spec)?\\.js$'],
+        pattern: '^apple(?:\\.js)?$',
+        message: 'Please import from fruit/apple/, not from apple',
+        exceptions: ['fruit/apple(?:\\.spec)?\\.js$'],
     },
     {
-        // For improved JS bundling
-        pattern: '^lodash(?:\\.js)?$',
-        message: 'Please import from e.g. lodash/foo, not from lodash directly',
+        pattern: '^grape/lib/grape(?:\\.js)?$',
+        message: 'Please import from grape, not from grape/lib/grape',
     },
     {
-        // For code consistency
-        pattern: '^mobx/lib/mobx(?:\\.js)?$',
-        message: 'Please import from mobx, not from mobx/lib/mobx',
+        pattern: '^lemon(?:\\.js)?$',
+        message: 'Please import from e.g. lemon/lib/foo, not from lemon directly',
     },
     {
-        // For correct configuration
-        pattern: '^moment(?:\\.js)?$',
-        message: 'Please import from utils/ud-moment, not from moment',
-        exceptions: ['utils/ud-moment(?:\\.spec)?\\.js$'],
-    },
-    {
-        // For correct configuration
-        pattern: '^numeral(?:\\.js)?$',
-        message: 'Please import from utils/ud-numeral, not from numeral',
-        exceptions: ['utils/ud-numeral(?:\\.spec)?\\.js$'],
-    },
-    {
-        // For improved JS bundling
-        pattern: '^react-bootstrap(?:\\.js)?$',
-        message: 'Please import from e.g. react-bootstrap/lib/foo, not from react-bootstrap directly',
-    },
-    {
-        // For correct implementation
-        pattern: '^react-bootstrap.*?$',
-        message: 'Please import from base-components/, not from react-bootstrap/',
-        exceptions: ['/base-components/'],
-    },
-    {
-        // For improved JS bundling
-        pattern: '^react-overlays(?:\\.js)?$',
-        message: 'Please import from e.g. react-overlays/lib/foo, not from react-overlays directly',
+        pattern: '^lemon.*?$',
+        message: 'Please import from lime/, not from lemon/',
+        exceptions: ['/lime/'],
     },
 ]];
 
 ruleTester.run('import-blacklist', rule, {
     valid: [
         {
-            code: "import currencyFormatter from 'currencyformatter.js';",
-            filename: path.join(__dirname, 'utils/currency-formatter.js'),
+            code: "import apple from 'apple.js';",
+            filename: path.join(__dirname, 'fruit/apple.js'),
             options,
         },
         {
-            code: "import example from 'lodash/example';",
+            code: "import apple from 'apple';",
+            filename: path.join(__dirname, 'fruit/apple.js'),
+            options,
+        },
+        {
+            code: "import grape from 'grape';",
             filename: path.join(__dirname, 'example.js'),
             options,
         },
         {
-            code: "import mobx from 'mobx';",
-            filename: path.join(__dirname, 'example.mobx-store.js'),
-            options,
-        },
-        {
-            code: "import moment from 'moment';",
-            filename: path.join(__dirname, 'utils/ud-moment.js'),
-            options,
-        },
-        {
-            code: "import numeral from 'numeral';",
-            filename: path.join(__dirname, 'utils/ud-numeral.js'),
-            options,
-        },
-        {
-            code: "import Example from 'react-bootstrap/lib/Example';",
-            filename: path.join(__dirname, 'base-components/example.react-component.js'),
-            options,
-        },
-        {
-            code: "import { Example } from 'react-overlays/lib/Example';",
-            filename: path.join(__dirname, 'example.react-component.js'),
+            code: "import foo from 'lemon/lib/foo';",
+            filename: path.join(__dirname, 'lime/example.js'),
             options,
         },
     ],
     invalid: [
         {
-            code: "import currencyFormatter from 'currencyformatter.js';",
-            errors: [{ message: 'Please import from utils/currency-formatter/, not from currencyformatter' }],
+            code: "import apple from 'apple.js';",
+            errors: [{ message: 'Please import from fruit/apple/, not from apple' }],
             filename: path.join(__dirname, 'example.js'),
             options,
         },
         {
-            code: "import { example } from 'lodash';",
-            errors: [{ message: 'Please import from e.g. lodash/foo, not from lodash directly' }],
+            code: "import apple from 'apple';",
+            errors: [{ message: 'Please import from fruit/apple/, not from apple' }],
             filename: path.join(__dirname, 'example.js'),
             options,
         },
         {
-            code: "import mobx from 'mobx/lib/mobx';",
-            errors: [{ message: 'Please import from mobx, not from mobx/lib/mobx' }],
-            filename: path.join(__dirname, 'example.mobx-store.js'),
-            options,
-        },
-        {
-            code: "import moment from 'moment';",
-            errors: [{ message: 'Please import from utils/ud-moment, not from moment' }],
+            code: "import grape from 'grape/lib/grape';",
+            errors: [{ message: 'Please import from grape, not from grape/lib/grape' }],
             filename: path.join(__dirname, 'example.js'),
             options,
         },
         {
-            code: "import numeral from 'numeral';",
-            errors: [{ message: 'Please import from utils/ud-numeral, not from numeral' }],
+            code: "import { foo } from 'lemon';",
+            errors: [{ message: 'Please import from e.g. lemon/lib/foo, not from lemon directly' }],
+            filename: path.join(__dirname, 'lime/example.js'),
+            options,
+        },
+        {
+            code: "import foo from 'lemon/lib/foo';",
+            errors: [{ message: 'Please import from lime/, not from lemon/' }],
             filename: path.join(__dirname, 'example.js'),
-            options,
-        },
-        {
-            code: "import { Example } from 'react-bootstrap';",
-            errors: [{ message: 'Please import from e.g. react-bootstrap/lib/foo, not from react-bootstrap directly' }],
-            filename: path.join(__dirname, 'base-components/example.react-component.js'),
-            options,
-        },
-        {
-            code: "import Example from 'react-bootstrap/lib/Example';",
-            errors: [{ message: 'Please import from base-components/, not from react-bootstrap/' }],
-            filename: path.join(__dirname, 'example.react-component.js'),
-            options,
-        },
-        {
-            code: "import { Example } from 'react-overlays';",
-            errors: [{ message: 'Please import from e.g. react-overlays/lib/foo, not from react-overlays directly' }],
-            filename: path.join(__dirname, 'example.react-component.js'),
             options,
         },
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,12 +1669,6 @@ eslint-plugin-jsx-a11y@^6.0.2:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^1.4.0"
 
-eslint-plugin-lodash@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-2.5.0.tgz#be23eb0c0b7b15c1fc3a46bf702b4be757446b45"
-  dependencies:
-    lodash "~4.17.0"
-
 eslint-plugin-promise@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
@@ -2836,7 +2830,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.0:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
##### *To:*
@cansin @udemy/team-f 

##### *What:*
feat: Introduce udemy/import-blacklist to prevent developers from writing certain imports.

##### *Trello:*
https://trello.com/c/O67N8QkA/1954-investigate-if-we-can-have-eslint-prevent-full-library-imports

##### *What did you test:*
I manually added import-blacklist/index.js to node_modules in website-django, and ran it against the codebase. It found a few bad imports for `'numeral'` :)

##### *What dashboards will you be monitoring:*
None
