### PR TITLE
docs: add import-blacklist to eslint-plugin-udemy

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.6.5"></a>
+## [0.6.5](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.4...babel-polyfill-udemy-website@0.6.5) (2018-04-24)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
 <a name="0.6.4"></a>
 ## [0.6.4](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.3...babel-polyfill-udemy-website@0.6.4) (2018-04-23)
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.17",
-    "eslint-config-udemy-website": "^4.1.0"
+    "eslint-config-udemy-basics": "^3.1.18",
+    "eslint-config-udemy-website": "^4.1.1"
   },
   "dependencies": {
     "babel-cli": "6.18.0",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.6.5"></a>
+## [0.6.5](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.6.4...babel-preset-udemy-website@0.6.5) (2018-04-24)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
 <a name="0.6.4"></a>
 ## [0.6.4](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.6.3...babel-preset-udemy-website@0.6.4) (2018-04-23)
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.17",
-    "eslint-config-udemy-website": "^4.1.0"
+    "eslint-config-udemy-basics": "^3.1.18",
+    "eslint-config-udemy-website": "^4.1.1"
   },
   "dependencies": {
     "babel-plugin-check-es2015-constants": "6.8.0",

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.18"></a>
+## [3.1.18](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.17...eslint-config-udemy-basics@3.1.18) (2018-04-24)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
 <a name="3.1.17"></a>
 ## [3.1.17](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.16...eslint-config-udemy-basics@3.1.17) (2018-04-23)
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "3.1.17",
+  "version": "3.1.18",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-udemy": "^4.1.0"
+    "eslint-plugin-udemy": "^4.1.1"
   },
   "peerDependencies": {
     "babel-eslint": "^8.0.2",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.1"></a>
+## [4.1.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.1.0...eslint-config-udemy-website@4.1.1) (2018-04-24)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
 <a name="4.1.0"></a>
 # [4.1.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.0.5...eslint-config-udemy-website@4.1.0) (2018-04-23)
 

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "eslint-config-udemy-babel-addons": "^1.0.9",
-    "eslint-config-udemy-basics": "^3.1.17",
+    "eslint-config-udemy-basics": "^3.1.18",
     "eslint-config-udemy-jasmine-addons": "^3.1.10",
     "eslint-config-udemy-react-addons": "^3.1.11",
     "eslint-import-resolver-webpack": "^0.8.3",

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.1"></a>
+## [4.1.1](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.1.0...eslint-plugin-udemy@4.1.1) (2018-04-24)
+
+
+
+
+**Note:** Version bump only for package eslint-plugin-udemy
+
 <a name="4.1.0"></a>
 # [4.1.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.0.3...eslint-plugin-udemy@4.1.0) (2018-04-23)
 

--- a/packages/eslint-plugin-udemy/README.md
+++ b/packages/eslint-plugin-udemy/README.md
@@ -20,6 +20,7 @@ You can then add the rules provided by this plugin to your `rules` section.
 
 # List of provided rules
 
+* [udemy/import-blacklist](rules/import-blacklist): Blacklist certain imports in JS files.
 * [udemy/angular-path-based-module-names](rules/angular-path-based-module-names): Require `angular.module` name to match relative file path.
 * [udemy/no-function-prototype](rules/no-function-prototype): Prefer `_.noop` or `() => {}` over `Function.prototype`.
 * [udemy/no-non-zero-settimeout](rules/no-non-zero-settimeout): Prevent `setTimeout` usages with a non-zero delay value.

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@cansin @udemy/team-f 

##### *What:*
docs: add import-blacklist (added in https://github.com/udemy/js-tooling/pull/20) to eslint-plugin-udemy

##### *Trello:*
https://trello.com/c/O67N8QkA/1954-investigate-if-we-can-have-eslint-prevent-full-library-imports

##### *What did you test:*
I previewed the [README](https://github.com/udemy/js-tooling/blob/fix/import-blacklist-docs/packages/eslint-plugin-udemy/README.md).

##### *What dashboards will you be monitoring:*
None
