### PR TITLE
Feature/import specifier blacklist

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.6.7"></a>
+## [0.6.7](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.5...babel-polyfill-udemy-website@0.6.7) (2018-05-01)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
 <a name="0.6.6"></a>
 ## [0.6.6](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.5...babel-polyfill-udemy-website@0.6.6) (2018-04-30)
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.18",
-    "eslint-config-udemy-website": "^4.1.2"
+    "eslint-config-udemy-basics": "^3.1.19",
+    "eslint-config-udemy-website": "^4.2.0"
   },
   "dependencies": {
     "babel-cli": "6.18.0",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.8.2"></a>
+## [0.8.2](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.8.0...babel-preset-udemy-website@0.8.2) (2018-05-01)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
 <a name="0.8.1"></a>
 ## [0.8.1](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.8.0...babel-preset-udemy-website@0.8.1) (2018-04-30)
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.18",
-    "eslint-config-udemy-website": "^4.1.2"
+    "eslint-config-udemy-basics": "^3.1.19",
+    "eslint-config-udemy-website": "^4.2.0"
   },
   "dependencies": {
     "babel-plugin-check-es2015-constants": "6.8.0",

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.19"></a>
+## [3.1.19](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.18...eslint-config-udemy-basics@3.1.19) (2018-05-01)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
 <a name="3.1.18"></a>
 ## [3.1.18](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.17...eslint-config-udemy-basics@3.1.18) (2018-04-24)
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "3.1.18",
+  "version": "3.1.19",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-udemy": "^4.1.1"
+    "eslint-plugin-udemy": "^4.2.0"
   },
   "peerDependencies": {
     "babel-eslint": "^8.0.2",

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.3.0"></a>
+# [3.3.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@3.1.11...eslint-config-udemy-react-addons@3.3.0) (2018-05-01)
+
+
+### Features
+
+* Introduce jsx-no-literals ([86c2b5c](https://github.com/udemy/js-tooling/commit/86c2b5c))
+
+
+
+
 <a name="3.2.0"></a>
 # [3.2.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@3.1.11...eslint-config-udemy-react-addons@3.2.0) (2018-04-30)
 

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.2.0"></a>
+# [4.2.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.1.1...eslint-config-udemy-website@4.2.0) (2018-05-01)
+
+
+### Features
+
+* Add a way to blacklist import specifiers. ([a310ea7](https://github.com/udemy/js-tooling/commit/a310ea7))
+* Blacklist BrowserRouter, HashRouter, Router from react-router-dom ([60b299a](https://github.com/udemy/js-tooling/commit/60b299a))
+
+
+
+
 <a name="4.1.2"></a>
 ## [4.1.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.1.1...eslint-config-udemy-website@4.1.2) (2018-04-30)
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -67,6 +67,14 @@ module.exports = {
                 source: '^react-overlays(?:\\.js)?$',
                 message: 'Please import from e.g. react-overlays/lib/foo, not from react-overlays directly',
             },
+            {
+                // For correct configuration
+                source: '^react-router-dom(?:\\.js)?$',
+                specifier: '^(BrowserRouter|HashRouter|Router)$',
+                message: 'Please `import MemoizedBrowserRouter from \'base-components/memoized-browser-router.react-component\';`, ' +
+                'not `import { BrowserRouter, HashRouter, Router } from \'react-router-dom\';`.',
+                exceptions: ['base-components/memoized-browser-router.react-component(?:\\.spec)?\\.js$'],
+            },
         ]],
         'underscore/prefer-noop': ['error', 'always'],
     },

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -25,46 +25,46 @@ module.exports = {
         'udemy/import-blacklist': ['error', [
             {
                 // For correct configuration
-                pattern: '^currencyformatter(?:\\.js)?$',
+                source: '^currencyformatter(?:\\.js)?$',
                 message: 'Please import from utils/currency-formatter/, not from currencyformatter',
                 exceptions: ['utils/currency-formatter(?:\\.spec)?\\.js$'],
             },
             {
                 // For improved JS bundling
-                pattern: '^lodash(?:\\.js)?$',
+                source: '^lodash(?:\\.js)?$',
                 message: 'Please import from e.g. lodash/foo, not from lodash directly',
             },
             {
                 // For code consistency
-                pattern: '^mobx/lib/mobx(?:\\.js)?$',
+                source: '^mobx/lib/mobx(?:\\.js)?$',
                 message: 'Please import from mobx, not from mobx/lib/mobx',
             },
             {
                 // For correct configuration
-                pattern: '^moment(?:\\.js)?$',
+                source: '^moment(?:\\.js)?$',
                 message: 'Please import from utils/ud-moment, not from moment',
                 exceptions: ['utils/ud-moment(?:\\.spec)?\\.js$'],
             },
             {
                 // For correct configuration
-                pattern: '^numeral(?:\\.js)?$',
+                source: '^numeral(?:\\.js)?$',
                 message: 'Please import from utils/ud-numeral, not from numeral',
                 exceptions: ['utils/ud-numeral(?:\\.spec)?\\.js$'],
             },
             {
                 // For improved JS bundling
-                pattern: '^react-bootstrap(?:\\.js)?$',
+                source: '^react-bootstrap(?:\\.js)?$',
                 message: 'Please import from e.g. react-bootstrap/lib/foo, not from react-bootstrap directly',
             },
             {
                 // For correct implementation
-                pattern: '^react-bootstrap.*?$',
+                source: '^react-bootstrap.*?$',
                 message: 'Please import from base-components/, not from react-bootstrap/',
                 exceptions: ['/base-components/'],
             },
             {
                 // For improved JS bundling
-                pattern: '^react-overlays(?:\\.js)?$',
+                source: '^react-overlays(?:\\.js)?$',
                 message: 'Please import from e.g. react-overlays/lib/foo, not from react-overlays directly',
             },
         ]],

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "eslint-config-udemy-babel-addons": "^1.0.9",
-    "eslint-config-udemy-basics": "^3.1.18",
+    "eslint-config-udemy-basics": "^3.1.19",
     "eslint-config-udemy-jasmine-addons": "^3.1.10",
-    "eslint-config-udemy-react-addons": "^3.2.0",
+    "eslint-config-udemy-react-addons": "^3.3.0",
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.8.0",

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.2.0"></a>
+# [4.2.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.1.1...eslint-plugin-udemy@4.2.0) (2018-05-01)
+
+
+### Features
+
+* Add a way to blacklist import specifiers. ([a310ea7](https://github.com/udemy/js-tooling/commit/a310ea7))
+
+
+
+
 <a name="4.1.1"></a>
 ## [4.1.1](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.1.0...eslint-plugin-udemy@4.1.1) (2018-04-24)
 

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
@@ -32,6 +32,8 @@ The following imports would error:
 ```js 
 import { bar } from 'foo';
 
+import { baz } from 'foo';
+
 import foo from 'foo';
 
 import foo from 'foo.js';
@@ -57,7 +59,7 @@ If we added:
 exceptions: ['bar\\.js'],
 ```
 
-then none of the imports in some-path/bar.js would error.
+then none of the imports in `some-path/bar.js` would error.
 
 ---
 
@@ -79,6 +81,8 @@ import { foo } from 'foo';
 The following imports would not error:
 
 ```js
+import { baz } from 'foo';
+
 import foo from 'foo';
 
 import foo from 'foo.js';

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
@@ -1,21 +1,27 @@
 # Import Blacklist
 
-`udemy/import-blacklist` blacklists certain imports in JS files. For example, it might tell you to `please import from e.g. foo/lib/bar, not from foo directly`. There are several reasons we enforce this rule:
+`udemy/import-blacklist` blacklists certain imports in JS files. For example, it might tell you to 
+`please import from e.g. foo/lib/bar, not from foo directly`. There are several reasons we enforce this rule:
 
-- Sometimes, a more specific import, e.g. `import bar from 'foo/lib/bar';`, can significantly reduce JS bundle size compared to e.g. `import { bar } from 'foo';`, since `'foo'` may contain many modules that the importing file is not actually using.
-- Some libraries have Udemy-specific wrappers that configure or extend the original library, in which case the library will only work properly if it is imported via the wrapper.
-- For code consistency, we may prefer one syntax over another. For example, if "main" in package.json points to `'foo/lib/foo'`, we may prefer `import foo from 'foo';` over `import foo from 'foo/lib/foo';`.
+- Sometimes, a more specific import, e.g. `import bar from 'foo/lib/bar';`, can significantly reduce JS bundle size 
+compared to e.g. `import { bar } from 'foo';`, since `'foo'` may contain many modules that the importing file is 
+not actually using.
+- Some libraries have Udemy-specific wrappers that configure or extend the original library, in which case the library 
+will only work properly if it is imported via the wrapper.
+- For code consistency, we may prefer one syntax over another. For example, if "main" in package.json points to 
+`'foo/lib/foo'`, we may prefer `import foo from 'foo';` over `import foo from 'foo/lib/foo';`.
 
 ## Rule details
 
-The blacklist is configured by a list of regexes. You may optionally specify a list of exception regexes to whitelist certain files from the blacklist.
+The blacklist is configured by a list of regexes. You may optionally specify a list of exception regexes to whitelist 
+certain files from the blacklist.
 
 Assuming the following configuration:
 
 ```js
 'udemy/import-blacklist': ['error', [
     {
-        pattern: '^foo(?:\\.js)?$',
+        source: '^foo(?:\\.js)?$',
         message: 'Please import from foo/lib/, not from foo',
     },
 ]]
@@ -24,6 +30,8 @@ Assuming the following configuration:
 The following imports would error:
 
 ```js 
+import { bar } from 'foo';
+
 import foo from 'foo';
 
 import foo from 'foo.js';
@@ -41,6 +49,8 @@ import foo from 'foo/lib/foo';
 import foo from 'foo.less';
 ```
 
+---
+
 If we added:
 
 ```js
@@ -48,3 +58,34 @@ exceptions: ['bar\\.js'],
 ```
 
 then none of the imports in some-path/bar.js would error.
+
+---
+
+If we added:
+
+```js
+specifier: '^(foo|bar)$',
+```
+
+The following imports would error:
+
+```js 
+
+import { bar } from 'foo';
+
+import { foo } from 'foo';
+```
+
+The following imports would not error:
+
+```js
+import foo from 'foo';
+
+import foo from 'foo.js';
+
+import 'foo';
+
+import foo from 'foo/lib/foo';
+
+import foo from 'foo.less';
+```

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/index.js
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/index.js
@@ -8,7 +8,10 @@ module.exports.rules = {
                 items: {
                     type: 'object',
                     properties: {
-                        pattern: {
+                        source: {
+                            type: 'string',
+                        },
+                        specifier: {
                             type: 'string',
                         },
                         message: {
@@ -21,7 +24,7 @@ module.exports.rules = {
                             },
                         },
                     },
-                    required: ['pattern', 'message'],
+                    required: ['source', 'message'],
                 },
             }],
         },
@@ -38,7 +41,13 @@ module.exports.rules = {
                         if (isException) {
                             return;
                         }
-                        const isBlacklisted = new RegExp(rule.pattern).test(node.source.value);
+
+                        let isBlacklisted = new RegExp(rule.source).test(node.source.value);
+                        if (rule.specifier) {
+                            isBlacklisted = isBlacklisted && node.specifiers.some(specifier => {
+                                return new RegExp(rule.specifier).test(specifier.imported && specifier.imported.name);
+                            });
+                        }
                         if (isBlacklisted) {
                             context.report({ node, message: rule.message });
                         }

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
@@ -13,22 +13,27 @@ const ruleTester = new RuleTester({
 
 const options = [[
     {
-        pattern: '^apple(?:\\.js)?$',
-        message: 'Please import from fruit/apple/, not from apple',
+        source: '^apple(?:\\.js)?$',
+        message: 'Please import from fruit/apple, not from apple',
         exceptions: ['fruit/apple(?:\\.spec)?\\.js$'],
     },
     {
-        pattern: '^grape/lib/grape(?:\\.js)?$',
+        source: '^grape/lib/grape(?:\\.js)?$',
         message: 'Please import from grape, not from grape/lib/grape',
     },
     {
-        pattern: '^lemon(?:\\.js)?$',
+        source: '^lemon(?:\\.js)?$',
         message: 'Please import from e.g. lemon/lib/foo, not from lemon directly',
     },
     {
-        pattern: '^lemon.*?$',
+        source: '^lemon.*?$',
         message: 'Please import from lime/, not from lemon/',
         exceptions: ['/lime/'],
+    },
+    {
+        source: '^pear(?:\\.js)?$',
+        specifier: '^Comice$',
+        message: 'Please import OurComice from our/comice, not import { Comice } from pear',
     },
 ]];
 
@@ -54,17 +59,22 @@ ruleTester.run('import-blacklist', rule, {
             filename: path.join(__dirname, 'lime/example.js'),
             options,
         },
+        {
+            code: "import { Bosc } from 'pear';",
+            filename: path.join(__dirname, 'example.js'),
+            options,
+        },
     ],
     invalid: [
         {
             code: "import apple from 'apple.js';",
-            errors: [{ message: 'Please import from fruit/apple/, not from apple' }],
+            errors: [{ message: 'Please import from fruit/apple, not from apple' }],
             filename: path.join(__dirname, 'example.js'),
             options,
         },
         {
             code: "import apple from 'apple';",
-            errors: [{ message: 'Please import from fruit/apple/, not from apple' }],
+            errors: [{ message: 'Please import from fruit/apple, not from apple' }],
             filename: path.join(__dirname, 'example.js'),
             options,
         },
@@ -83,6 +93,12 @@ ruleTester.run('import-blacklist', rule, {
         {
             code: "import foo from 'lemon/lib/foo';",
             errors: [{ message: 'Please import from lime/, not from lemon/' }],
+            filename: path.join(__dirname, 'example.js'),
+            options,
+        },
+        {
+            code: "import { Comice } from 'pear';",
+            errors: [{ message: 'Please import OurComice from our/comice, not import { Comice } from pear' }],
             filename: path.join(__dirname, 'example.js'),
             options,
         },


### PR DESCRIPTION
##### *To:*
@kevinzang cc: @udemy/team-f 

##### *What:*
1. Add a way to blacklist import specifiers.
2. Blacklist BrowserRouter, HashRouter, Router from react-router-dom

This is going to be merged after https://github.com/udemy/website-django/pull/24606

##### *Trello:*
Part of 

##### *What did you test:*
Added new test scenarious and ran `yarn test`. Also tested the current configuration against https://github.com/udemy/website-django/pull/24606

##### *What dashboards will you be monitoring:*
None
