### PR TITLE
improvement: allow .videojs-component.js

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.0"></a>
+# [3.0.0](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@0.6.6...babel-polyfill-udemy-website@3.0.0) (2018-06-05)
+
+
+### Features
+
+* include all of Babel's external helpers ([b1a84c5](https://github.com/udemy/js-tooling/commit/b1a84c5))
+* Use babel-polyfill and babel-preset-env ([#27](https://github.com/udemy/js-tooling/issues/27)) ([f59b2ee](https://github.com/udemy/js-tooling/commit/f59b2ee))
+
+
+### BREAKING CHANGES
+
+* And remove custom config for polyfills and plugins.
+* renamed `helpers.js` to `babel-external-helpers.js`
+
+
+
+
 <a name="2.0.0"></a>
 # [2.0.0](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@1.0.0...babel-polyfill-udemy-website@2.0.0) (2018-06-04)
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.19",
-    "eslint-config-udemy-website": "^4.2.0"
+    "eslint-config-udemy-basics": "^3.1.20",
+    "eslint-config-udemy-website": "^4.3.0"
   },
   "dependencies": {
     "babel-cli": "6.18.0",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.0"></a>
+# [3.0.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@0.8.1...babel-preset-udemy-website@3.0.0) (2018-06-05)
+
+
+### Features
+
+* include all of Babel's external helpers ([b1a84c5](https://github.com/udemy/js-tooling/commit/b1a84c5))
+* Use babel-polyfill and babel-preset-env ([#27](https://github.com/udemy/js-tooling/issues/27)) ([f59b2ee](https://github.com/udemy/js-tooling/commit/f59b2ee))
+
+
+### BREAKING CHANGES
+
+* And remove custom config for polyfills and plugins.
+* renamed `helpers.js` to `babel-external-helpers.js`
+
+
+
+
 <a name="2.0.0"></a>
 # [2.0.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@1.0.0...babel-preset-udemy-website@2.0.0) (2018-06-04)
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.19",
-    "eslint-config-udemy-website": "^4.2.0"
+    "eslint-config-udemy-basics": "^3.1.20",
+    "eslint-config-udemy-website": "^4.3.0"
   },
   "dependencies": {
     "babel-plugin-external-helpers": "6.18.0",

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.20"></a>
+## [3.1.20](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.18...eslint-config-udemy-basics@3.1.20) (2018-06-05)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
 <a name="3.1.19"></a>
 ## [3.1.19](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.18...eslint-config-udemy-basics@3.1.19) (2018-05-01)
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "3.1.19",
+  "version": "3.1.20",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-udemy": "^4.2.0"
+    "eslint-plugin-udemy": "^4.3.0"
   },
   "peerDependencies": {
     "babel-eslint": "^8.0.2",

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.3.1"></a>
+## [3.3.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@3.2.0...eslint-config-udemy-react-addons@3.3.1) (2018-06-05)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-react-addons
+
 <a name="3.3.0"></a>
 # [3.3.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@3.1.11...eslint-config-udemy-react-addons@3.3.0) (2018-05-01)
 

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.3.0"></a>
+# [4.3.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.1.2...eslint-config-udemy-website@4.3.0) (2018-06-05)
+
+
+### Features
+
+* Add a way to blacklist import specifiers. ([a310ea7](https://github.com/udemy/js-tooling/commit/a310ea7))
+* Blacklist BrowserRouter, HashRouter, Router from react-router-dom ([60b299a](https://github.com/udemy/js-tooling/commit/60b299a))
+
+
+
+
 <a name="4.2.0"></a>
 # [4.2.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.1.1...eslint-config-udemy-website@4.2.0) (2018-05-01)
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -20,7 +20,7 @@ module.exports = {
         },
     },
     rules: {
-        'filenames/match-regex': ['error', '^(?:[a-z0-9\\-]+(?:\\.(?:ng-(?:constant|controller|directive|factory|filter|provider|service)|react-(?:component|proptypes)|mobx-(?:model|store)))?(?:\\.spec)?)$'],
+        'filenames/match-regex': ['error', '^(?:[a-z0-9\\-]+(?:\\.(?:ng-(?:constant|controller|directive|factory|filter|provider|service)|videojs-component|react-(?:component|proptypes)|mobx-(?:model|store)))?(?:\\.spec)?)$'],
         'udemy/angular-path-based-module-names': ['error', 'always'],
         'udemy/import-blacklist': ['error', [
             {

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "eslint-config-udemy-babel-addons": "^1.0.9",
-    "eslint-config-udemy-basics": "^3.1.19",
+    "eslint-config-udemy-basics": "^3.1.20",
     "eslint-config-udemy-jasmine-addons": "^3.1.10",
-    "eslint-config-udemy-react-addons": "^3.3.0",
+    "eslint-config-udemy-react-addons": "^3.3.1",
     "eslint-import-resolver-webpack": "^0.8.3",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.8.0",

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.3.0"></a>
+# [4.3.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.1.1...eslint-plugin-udemy@4.3.0) (2018-06-05)
+
+
+### Features
+
+* Add a way to blacklist import specifiers. ([a310ea7](https://github.com/udemy/js-tooling/commit/a310ea7))
+
+
+
+
 <a name="4.2.0"></a>
 # [4.2.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.1.1...eslint-plugin-udemy@4.2.0) (2018-05-01)
 

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@cansin @udemy/team-f @udemy/team-t 

##### *What:*
improvement: allow .videojs-component.js file extension. Team T is using it for files such as https://github.com/udemy/website-django/blob/master/static/src/udemy/js/video-player/captions-menu/captions-menu.videojs-component.js.

##### *Trello:*
None

##### *What did you test:*
I applied this change manually by updating node_modules in website-django repo. I verified we can remove `/* eslint-disable filenames/match-regex */` from the .videojs-component.js files.

##### *What dashboards will you be monitoring:*
None
