### PR TITLE
eslint-plugin-udemy/import-blacklist: allow regex matches to be referenced in the error message

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.2"></a>
+## [3.0.2](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@3.0.1...babel-polyfill-udemy-website@3.0.2) (2018-06-15)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
 <a name="3.0.1"></a>
 ## [3.0.1](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@3.0.0...babel-polyfill-udemy-website@3.0.1) (2018-06-06)
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.20",
-    "eslint-config-udemy-website": "^4.3.1"
+    "eslint-config-udemy-basics": "^3.1.21",
+    "eslint-config-udemy-website": "^4.3.2"
   },
   "dependencies": {
     "babel-cli": "6.18.0",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.0.1"></a>
+## [4.0.1](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@4.0.0...babel-preset-udemy-website@4.0.1) (2018-06-15)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
 <a name="4.0.0"></a>
 # [4.0.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@3.0.1...babel-preset-udemy-website@4.0.0) (2018-06-11)
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^3.1.20",
-    "eslint-config-udemy-website": "^4.3.1"
+    "eslint-config-udemy-basics": "^3.1.21",
+    "eslint-config-udemy-website": "^4.3.2"
   },
   "dependencies": {
     "babel-plugin-external-helpers": "6.18.0",

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.21"></a>
+## [3.1.21](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.20...eslint-config-udemy-basics@3.1.21) (2018-06-15)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
 <a name="3.1.20"></a>
 ## [3.1.20](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@3.1.18...eslint-config-udemy-basics@3.1.20) (2018-06-05)
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "3.1.20",
+  "version": "3.1.21",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-udemy": "^4.3.0"
+    "eslint-plugin-udemy": "^4.4.0"
   },
   "peerDependencies": {
     "babel-eslint": "^8.0.2",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.3.2"></a>
+## [4.3.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.3.1...eslint-config-udemy-website@4.3.2) (2018-06-15)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
 <a name="4.3.1"></a>
 ## [4.3.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.3.0...eslint-config-udemy-website@4.3.1) (2018-06-06)
 

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "eslint-config-udemy-babel-addons": "^1.0.9",
-    "eslint-config-udemy-basics": "^3.1.20",
+    "eslint-config-udemy-basics": "^3.1.21",
     "eslint-config-udemy-jasmine-addons": "^3.1.10",
     "eslint-config-udemy-react-addons": "^3.3.2",
     "eslint-import-resolver-webpack": "^0.8.3",

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.4.0"></a>
+# [4.4.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.3.0...eslint-plugin-udemy@4.4.0) (2018-06-15)
+
+
+### Features
+
+* regex matches can be referenced in the message ([484cf6b](https://github.com/udemy/js-tooling/commit/484cf6b))
+
+
+
+
 <a name="4.3.0"></a>
 # [4.3.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@4.1.1...eslint-plugin-udemy@4.3.0) (2018-06-05)
 

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/README.md
@@ -93,3 +93,20 @@ import foo from 'foo/lib/foo';
 
 import foo from 'foo.less';
 ```
+
+---
+
+You may reference the regex matches in the error message. `$i` references the ith match. Matches in the `specifier` are ordered after matches in the `source`. For example, given the following config,
+
+```js
+source: '^(thing)$'
+specifier: '^(foo|bar)$'
+message: 'Please import { $2 } from custom/$1, not import { $2 } from $1
+```
+
+the following messages are possible:
+
+```js
+Please import { foo } from custom/thing, not import { foo } from thing
+Please import { bar } from custom/thing, not import { bar } from thing
+```

--- a/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
+++ b/packages/eslint-plugin-udemy/rules/import-blacklist/tests.js
@@ -18,6 +18,11 @@ const options = [[
         exceptions: ['fruit/apple(?:\\.spec)?\\.js$'],
     },
     {
+        source: '^(peach|pecan)(?:\\.js)?$',
+        message: 'Please import from fruit/$1, not from $1',
+        exceptions: ['fruit/(?:peach|pecan)(?:\\.spec)?\\.js$'],
+    },
+    {
         source: '^grape/lib/grape(?:\\.js)?$',
         message: 'Please import from grape, not from grape/lib/grape',
     },
@@ -35,6 +40,11 @@ const options = [[
         specifier: '^Comice$',
         message: 'Please import OurComice from our/comice, not import { Comice } from pear',
     },
+    {
+        source: '^(berry)(?:\\.js)?$',
+        specifier: '^(BlueBerry|BlackBerry)$',
+        message: 'Please import { $2 } from our/$1, not import { $2 } from $1',
+    },
 ]];
 
 ruleTester.run('import-blacklist', rule, {
@@ -42,6 +52,16 @@ ruleTester.run('import-blacklist', rule, {
         {
             code: "import apple from 'apple.js';",
             filename: path.join(__dirname, 'fruit/apple.js'),
+            options,
+        },
+        {
+            code: "import peach from 'peach.js';",
+            filename: path.join(__dirname, 'fruit/peach.js'),
+            options,
+        },
+        {
+            code: "import pecan from 'pecan.js';",
+            filename: path.join(__dirname, 'fruit/pecan.js'),
             options,
         },
         {
@@ -64,11 +84,28 @@ ruleTester.run('import-blacklist', rule, {
             filename: path.join(__dirname, 'example.js'),
             options,
         },
+        {
+            code: "import { StrawBerry } from 'berry';",
+            filename: path.join(__dirname, 'example.js'),
+            options,
+        },
     ],
     invalid: [
         {
             code: "import apple from 'apple.js';",
             errors: [{ message: 'Please import from fruit/apple, not from apple' }],
+            filename: path.join(__dirname, 'example.js'),
+            options,
+        },
+        {
+            code: "import peach from 'peach.js';",
+            errors: [{ message: 'Please import from fruit/peach, not from peach' }],
+            filename: path.join(__dirname, 'example.js'),
+            options,
+        },
+        {
+            code: "import pecan from 'pecan.js';",
+            errors: [{ message: 'Please import from fruit/pecan, not from pecan' }],
             filename: path.join(__dirname, 'example.js'),
             options,
         },
@@ -99,6 +136,18 @@ ruleTester.run('import-blacklist', rule, {
         {
             code: "import { Comice } from 'pear';",
             errors: [{ message: 'Please import OurComice from our/comice, not import { Comice } from pear' }],
+            filename: path.join(__dirname, 'example.js'),
+            options,
+        },
+        {
+            code: "import { BlueBerry } from 'berry';",
+            errors: [{ message: 'Please import { BlueBerry } from our/berry, not import { BlueBerry } from berry' }],
+            filename: path.join(__dirname, 'example.js'),
+            options,
+        },
+        {
+            code: "import { BlackBerry } from 'berry';",
+            errors: [{ message: 'Please import { BlackBerry } from our/berry, not import { BlackBerry } from berry' }],
             filename: path.join(__dirname, 'example.js'),
             options,
         },


### PR DESCRIPTION
##### *To:*
@inancsevinc @udemy/team-f 

##### *What:*
eslint-plugin-udemy/import-blacklist: allow regex matches to be referenced in the error message.

##### *Trello:*
None

##### *What did you test:*
I copied the changes over to website-django and verified that `yarn run lint` passed.

To confirm that the new feature works:

```
// eslint-config-udemy-website/index.js
{
    // For correct configuration
    source: '^(moment|numeral)(?:\\.js)?$',
    message: 'TEST: Please import from utils/ud-$1, not from $1',
    exceptions: ['utils/ud-(moment|numeral)(?:\\.spec)?\\.js$'],
}

// presentation-asset.mobx-store.spec.js
import moment from 'moment';

// course-comparison-item.react-component.spec.js
import numeral from 'numeral';
```

`yarn run lint`

Verify error messages:

```
/Users/kevinzhang/Desktop/website/website-django/static/src/udemy/js/asset/presentation/presentation-asset.mobx-store.spec.js
  2:1  error  TEST: Please import from utils/ud-moment, not from moment  udemy/import-blacklist

/Users/kevinzhang/Desktop/website/website-django/static/src/udemy/js/course-comparison/course-comparison-item.react-component.spec.js
  7:1  error  TEST: Please import from utils/ud-numeral, not from numeral  udemy/import-blacklist
```

##### *What dashboards will you be monitoring:*
None
