### PR TITLE
import-blacklist enzyme/build/index in favor of enzyme

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,8 @@
 ##### *What:*
 <Describe the changes you're introducing, along with the motivation for doing so>
 
-##### *Trello:*
-<Link to the Trello card for this PR or use the Trello/GitHub integration and remove this>
+##### *JIRA:*
+<Link to the JIRA issue for this PR or use the JIRA-Github integration and remove this>
 
 ##### *What did you test:*
 <Any manual testing you've done in addition to the automated tests>

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ Run tests to verify everything is working.
 1. Run `yarn test` to make sure all tests pass.
 1. Commit/push your changes.
 1. Create a pull request against master.
-1. Once your pull request is approved, run `lerna publish` in order to publish your changes to npm.
+1. Get your pull request approved by a Team F member.
+1. Run `git fetch origin --tags`. This is important for the `lerna publish` step below, as lerna checks git tags to determine what changed. See [https://github.com/lerna/lerna#updated](https://github.com/lerna/lerna#updated).
+1. Get the latest code from master, via either pull or rebase. This is important for the `lerna publish` step below. If you have a merge conflict, lerna will fail to automatically push its "Publish" commit to your branch.
+1. Run `lerna publish` in order to publish your changes to npm.
    - Ideally we would first merge the pull request to master, then publish master to npm, but `lerna publish`
      creates a "Publish" commit which would have to be pushed to master, and non-admins cannot push
      directly to master.

--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.0.0"></a>
+# [5.0.0](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@3.0.2...babel-polyfill-udemy-website@5.0.0) (2018-06-20)
+
+
+* TF-3508 TF-3509 Upgraded babel, changed the defaults for @babel/preset-env, and added the react preset (#30) ([f0b4569](https://github.com/udemy/js-tooling/commit/f0b4569))
+
+
+### BREAKING CHANGES
+
+* It may be possible this results in breakages.
+
+See: https://new.babeljs.io/docs/en/next/v7-migration.html
+
+* feat: Tweaked the babel-preset-env config, including for polyfills
+* The list of supported browsers is very slightly
+different with respect to some edge cases.
+
+* feat: Switched to using @babel/preset-react
+
+
+
+
 <a name="4.0.0"></a>
 # [4.0.0](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@3.0.2...babel-polyfill-udemy-website@4.0.0) (2018-06-16)
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^3.1.21",
-    "eslint-config-udemy-website": "^4.3.2"
+    "eslint-config-udemy-website": "^4.4.0"
   },
   "dependencies": {
     "@babel/cli": "7.0.0-beta.49",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="6.0.0"></a>
+# [6.0.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@4.0.1...babel-preset-udemy-website@6.0.0) (2018-06-20)
+
+
+* TF-3508 TF-3509 Upgraded babel, changed the defaults for @babel/preset-env, and added the react preset (#30) ([f0b4569](https://github.com/udemy/js-tooling/commit/f0b4569))
+
+
+### BREAKING CHANGES
+
+* It may be possible this results in breakages.
+
+See: https://new.babeljs.io/docs/en/next/v7-migration.html
+
+* feat: Tweaked the babel-preset-env config, including for polyfills
+* The list of supported browsers is very slightly
+different with respect to some edge cases.
+
+* feat: Switched to using @babel/preset-react
+
+
+
+
 <a name="5.0.0"></a>
 # [5.0.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@4.0.1...babel-preset-udemy-website@5.0.0) (2018-06-16)
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^8.2.1",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^3.1.21",
-    "eslint-config-udemy-website": "^4.3.2"
+    "eslint-config-udemy-website": "^4.4.0"
   },
   "dependencies": {
     "@babel/core": "7.0.0-beta.49",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.4.0"></a>
+# [4.4.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.3.2...eslint-config-udemy-website@4.4.0) (2018-06-20)
+
+
+### Features
+
+* import blacklist enzyme/build/index ([8568456](https://github.com/udemy/js-tooling/commit/8568456))
+
+
+
+
 <a name="4.3.2"></a>
 ## [4.3.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.3.1...eslint-config-udemy-website@4.3.2) (2018-06-15)
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -30,6 +30,11 @@ module.exports = {
                 exceptions: ['utils/currency-formatter(?:\\.spec)?\\.js$'],
             },
             {
+                // For code consistency
+                source: '^enzyme/build/index(?:\\.js)?$',
+                message: 'Please import from enzyme, not from enzyme/build/index',
+            },
+            {
                 // For improved JS bundling
                 source: '^lodash(?:\\.js)?$',
                 message: 'Please import from e.g. lodash/foo, not from lodash directly',

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "4.3.2",
+  "version": "4.4.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@cansin @udemy/team-f 

##### *What:*
Pedantic PR:

- import-blacklist enzyme/build/index in favor of enzyme
- update the PR template to reference Jira instead of Trello
- update the docs to include `git fetch origin --tags` and `git pull` steps

##### *Trello:*
None

##### *What did you test:*
I copied the changes over to website-django, and ran `yarn run lint` to find the files that were importing from enzyme/build/index. Django PR to fix those imports: https://github.com/udemy/website-django/pull/25988.

##### *What dashboards will you be monitoring:*
None
