### PR TITLE
Import blacklist Link from react-router-dom

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="7.0.1"></a>
+       <a name="7.0.2"></a>
+## [7.0.2](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.1...babel-polyfill-udemy-website@7.0.2) (2018-07-18)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+       <a name="7.0.1"></a>
 ## [7.0.1](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.0...babel-polyfill-udemy-website@7.0.1) (2018-07-11)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
- <a name="7.0.0"></a>
+<a name="7.0.0"></a>
 # [7.0.0](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@5.0.0...babel-polyfill-udemy-website@7.0.0) (2018-06-29)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^8.2.5",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^5.0.0",
-    "eslint-config-udemy-website": "^7.0.0"
+    "eslint-config-udemy-website": "^7.1.0"
   },
   "dependencies": {
     "@babel/cli": "7.0.0-beta.49",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="8.0.1"></a>
+       <a name="8.0.2"></a>
+## [8.0.2](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.1...babel-preset-udemy-website@8.0.2) (2018-07-18)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+       <a name="8.0.1"></a>
 ## [8.0.1](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.0...babel-preset-udemy-website@8.0.1) (2018-07-11)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
- <a name="8.0.0"></a>
+<a name="8.0.0"></a>
 # [8.0.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@6.0.0...babel-preset-udemy-website@8.0.0) (2018-06-29)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -22,7 +22,7 @@
     "babel-eslint": "^8.2.5",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^5.0.0",
-    "eslint-config-udemy-website": "^7.0.0"
+    "eslint-config-udemy-website": "^7.1.0"
   },
   "dependencies": {
     "@babel/plugin-external-helpers": "7.0.0-beta.49",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="7.0.0"></a>
+       <a name="7.1.0"></a>
+# [7.1.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.0.0...eslint-config-udemy-website@7.1.0) (2018-07-18)
+
+
+### Features
+
+* import blacklist Link from react-router-dom ([3db4b23](https://github.com/udemy/js-tooling/commit/3db4b23))
+
+
+
+
+       <a name="7.0.0"></a>
 # [7.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@6.0.0...eslint-config-udemy-website@7.0.0) (2018-07-11)
 
 
@@ -19,7 +30,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
- <a name="6.0.0"></a>
+<a name="6.0.0"></a>
 # [6.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@4.4.0...eslint-config-udemy-website@6.0.0) (2018-06-29)
 
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -93,6 +93,14 @@ module.exports = {
                 'not `import { BrowserRouter, HashRouter, Router } from \'react-router-dom\';`.',
                 exceptions: ['base-components/memoized-browser-router.react-component(?:\\.spec)?\\.js$'],
             },
+            {
+                // For correct implementation
+                source: '^react-router-dom(?:\\.js)?$',
+                specifier: '^Link$',
+                message: 'Please `import Link from \'base-components/link.react-component\';`, ' +
+                'not `import { Link } from \'react-router-dom\';`.',
+                exceptions: ['base-components/link.react-component(?:\\.spec)?\\.js$'],
+            },
         ]],
         'underscore/prefer-noop': ['error', 'always'],
     },

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@jjinux @udemy/team-f @udemy/team-browse 

##### *What:*
Import blacklist Link from react-router-dom. In https://github.com/udemy/website-django/pull/26734/files, the Browse team is introducing base-components/link.react-component.js which should be imported instead.

##### *JIRA:*
None

##### *What did you test:*
I applied the changes manually on the https://github.com/udemy/website-django/pull/26734/files branch, and verified `yarn run lint` passed. I changed one of the imports to import Link from react-router-dom, and verified `yarn run lint` failed.

##### *What dashboards will you be monitoring:*
None
