### PR TITLE
TF-3610 fix: adding eslint-import-resolver-node

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="7.0.7"></a>
+       <a name="7.0.8"></a>
+## [7.0.8](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.7...babel-polyfill-udemy-website@7.0.8) (2018-09-24)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+       <a name="7.0.7"></a>
 ## [7.0.7](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.6...babel-polyfill-udemy-website@7.0.7) (2018-09-24)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
- <a name="7.0.6"></a>
+<a name="7.0.6"></a>
 ## [7.0.6](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.5...babel-polyfill-udemy-website@7.0.6) (2018-09-12)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^8.2.5",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^5.0.3",
-    "eslint-config-udemy-website": "^7.1.5"
+    "eslint-config-udemy-basics": "^5.0.4",
+    "eslint-config-udemy-website": "^7.1.6"
   },
   "dependencies": {
     "@babel/cli": "7.0.0-beta.49",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="8.0.7"></a>
+       <a name="8.0.8"></a>
+## [8.0.8](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.7...babel-preset-udemy-website@8.0.8) (2018-09-24)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+       <a name="8.0.7"></a>
 ## [8.0.7](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.6...babel-preset-udemy-website@8.0.7) (2018-09-24)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
- <a name="8.0.6"></a>
+<a name="8.0.6"></a>
 ## [8.0.6](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.5...babel-preset-udemy-website@8.0.6) (2018-09-12)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,8 +21,8 @@
     "@babel/core": "7.0.0-beta.49",
     "babel-eslint": "^8.2.5",
     "eslint": "^4.11.0",
-    "eslint-config-udemy-basics": "^5.0.3",
-    "eslint-config-udemy-website": "^7.1.5"
+    "eslint-config-udemy-basics": "^5.0.4",
+    "eslint-config-udemy-website": "^7.1.6"
   },
   "dependencies": {
     "@babel/plugin-external-helpers": "7.0.0-beta.49",

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,7 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="5.0.3"></a>
+       <a name="5.0.4"></a>
+## [5.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@5.0.3...eslint-config-udemy-basics@5.0.4) (2018-09-24)
+
+
+### Bug Fixes
+
+* adding eslint-import-resolver-node ([243009a](https://github.com/udemy/js-tooling/commit/243009a))
+
+
+
+
+       <a name="5.0.3"></a>
 ## [5.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@5.0.2...eslint-config-udemy-basics@5.0.3) (2018-09-24)
 
 
@@ -11,7 +22,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-basics
 
- <a name="5.0.2"></a>
+<a name="5.0.2"></a>
 ## [5.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@5.0.1...eslint-config-udemy-basics@5.0.2) (2018-09-12)
 
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "dependencies": {
+    "eslint-import-resolver-node": "^0.3.2",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import-order-alphabetical": "^0.0.1",
     "eslint-plugin-promise": "^3.6.0",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="7.1.5"></a>
+       <a name="7.1.6"></a>
+## [7.1.6](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.1.5...eslint-config-udemy-website@7.1.6) (2018-09-24)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
+       <a name="7.1.5"></a>
 ## [7.1.5](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.1.4...eslint-config-udemy-website@7.1.5) (2018-09-24)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
- <a name="7.1.4"></a>
+<a name="7.1.4"></a>
 ## [7.1.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.1.3...eslint-config-udemy-website@7.1.4) (2018-09-12)
 
 

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "7.1.5",
+  "version": "7.1.6",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "eslint-config-udemy-babel-addons": "^3.0.0",
-    "eslint-config-udemy-basics": "^5.0.3",
+    "eslint-config-udemy-basics": "^5.0.4",
     "eslint-config-udemy-jasmine-addons": "^5.0.0",
     "eslint-config-udemy-react-addons": "^5.0.0",
     "eslint-import-resolver-webpack": "^0.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,7 +1662,7 @@ dateformat@^1.0.11, dateformat@^1.0.12:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1879,6 +1879,13 @@ eslint-import-resolver-node@^0.3.1:
   dependencies:
     debug "^2.6.8"
     resolve "^1.2.0"
+
+eslint-import-resolver-node@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.5.0"
 
 eslint-import-resolver-webpack@^0.8.3:
   version "0.8.3"
@@ -4266,7 +4273,7 @@ resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.6.0:
+resolve@^1.5.0, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:


### PR DESCRIPTION
##### *To:*
@team-f @jjinux @inancsevinc 

##### *What:*
I am adding eslint-import-resolver-node which we need for import-order-alphabetical to work in e2e and axe.

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3610

##### *What did you test:*
`yarn test`

##### *What dashboards will you be monitoring:*
N/A