### PR TITLE
Add npgettext to list of acceptable global variables

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="7.0.8"></a>
+ <a name="7.0.9"></a>
+## [7.0.9](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.8...babel-polyfill-udemy-website@7.0.9) (2018-10-03)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+ <a name="7.0.8"></a>
 ## [7.0.8](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.7...babel-polyfill-udemy-website@7.0.8) (2018-09-24)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
-       <a name="7.0.7"></a>
+<a name="7.0.7"></a>
 ## [7.0.7](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.6...babel-polyfill-udemy-website@7.0.7) (2018-09-24)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "7.0.8",
+  "version": "7.0.9",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^8.2.5",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^5.0.4",
-    "eslint-config-udemy-website": "^7.1.6"
+    "eslint-config-udemy-website": "^7.1.7"
   },
   "dependencies": {
     "@babel/cli": "7.0.0-beta.49",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="8.0.8"></a>
+ <a name="8.0.9"></a>
+## [8.0.9](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.8...babel-preset-udemy-website@8.0.9) (2018-10-03)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+ <a name="8.0.8"></a>
 ## [8.0.8](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.7...babel-preset-udemy-website@8.0.8) (2018-09-24)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
-       <a name="8.0.7"></a>
+<a name="8.0.7"></a>
 ## [8.0.7](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.6...babel-preset-udemy-website@8.0.7) (2018-09-24)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "8.0.8",
+  "version": "8.0.9",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -22,7 +22,7 @@
     "babel-eslint": "^8.2.5",
     "eslint": "^4.11.0",
     "eslint-config-udemy-basics": "^5.0.4",
-    "eslint-config-udemy-website": "^7.1.6"
+    "eslint-config-udemy-website": "^7.1.7"
   },
   "dependencies": {
     "@babel/plugin-external-helpers": "7.0.0-beta.49",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="7.1.6"></a>
+ <a name="7.1.7"></a>
+## [7.1.7](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.1.6...eslint-config-udemy-website@7.1.7) (2018-10-03)
+
+
+### Bug Fixes
+
+* Add npgettext to list of acceptable global variables ([3923fac](https://github.com/udemy/js-tooling/commit/3923fac))
+
+
+
+
+ <a name="7.1.6"></a>
 ## [7.1.6](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.1.5...eslint-config-udemy-website@7.1.6) (2018-09-24)
 
 
@@ -11,7 +22,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
-       <a name="7.1.5"></a>
+<a name="7.1.5"></a>
 ## [7.1.5](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.1.4...eslint-config-udemy-website@7.1.5) (2018-09-24)
 
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -124,6 +124,7 @@ module.exports = {
         angular: false,
         gettext: false,
         ngettext: false,
+        npgettext: false,
         pgettext: false,
         interpolate: false,
         ninterpolate: false,

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "7.1.6",
+  "version": "7.1.7",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@jjinux @udemy/team-f 

##### *What:*
Add npgettext to list of acceptable global variables. This is following the steps of https://github.com/udemy/js-tooling/pull/13, which did the same thing for pgettext.

pgettext is basically gettext with a comment to explain the context of the translation.
npgettext is basically pgettext but with support for pluralized strings.

##### *JIRA:*
None

##### *What did you test:*
I applied the change manually in website-django and verified I can remove `eslint-disable no-def` in https://github.com/udemy/website-django/pull/28949.

##### *What dashboards will you be monitoring:*
None
