### PR TITLE
fix: Make sure to use legacy decorators for linting

### DIFF
--- a/packages/eslint-config-udemy-babel-addons/parts/babel.js
+++ b/packages/eslint-config-udemy-babel-addons/parts/babel.js
@@ -2,6 +2,11 @@
 
 module.exports = {
     parser: 'babel-eslint',
+    parserOptions: {
+        ecmaFeatures: {
+            legacyDecorators: true,
+        },
+    },
     plugins: [
         'babel',
     ],


### PR DESCRIPTION
##### *To:*
@udemy/team-f 

##### *What:*
I realized bumping ESLint version required us to add a legacyDecorators config.

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3646

##### *What did you test:*
Run `eslint ./` on website-django repo.

##### *What dashboards will you be monitoring:*
None
