### PR TITLE
BREAKING CHANGE: Upgrade eslint to 5.x and node to 8.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   },
   "scripts": {

--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="7.0.12"></a>
+ <a name="8.0.0"></a>
+# [8.0.0](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.12...babel-polyfill-udemy-website@8.0.0) (2018-11-09)
+
+
+### Features
+
+* Upgrade eslint to 5.x ([1655e2f](https://github.com/udemy/js-tooling/commit/1655e2f))
+
+
+### BREAKING CHANGES
+
+* Upgrade ESLint to ^5.9.0 and require node >=8.12.0 as an engine.
+
+
+
+
+ <a name="7.0.12"></a>
 ## [7.0.12](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.11...babel-polyfill-udemy-website@7.0.12) (2018-11-06)
 
 
@@ -11,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
-       <a name="7.0.11"></a>
+<a name="7.0.11"></a>
 ## [7.0.11](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@7.0.10...babel-polyfill-udemy-website@7.0.11) (2018-11-06)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "7.0.12",
+  "version": "8.0.0",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^5.0.5",
-    "eslint-config-udemy-website": "^7.1.10"
+    "eslint-config-udemy-basics": "^6.0.0",
+    "eslint-config-udemy-website": "^8.0.0"
   },
   "dependencies": {
     "@babel/cli": "^7.1.2",

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^4.19.1",
+    "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^5.0.5",
     "eslint-config-udemy-website": "^7.1.10"
   },

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="8.0.14"></a>
+ <a name="9.0.0"></a>
+# [9.0.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.14...babel-preset-udemy-website@9.0.0) (2018-11-09)
+
+
+### Features
+
+* Upgrade eslint to 5.x ([1655e2f](https://github.com/udemy/js-tooling/commit/1655e2f))
+
+
+### BREAKING CHANGES
+
+* Upgrade ESLint to ^5.9.0 and require node >=8.12.0 as an engine.
+
+
+
+
+ <a name="8.0.14"></a>
 ## [8.0.14](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.13...babel-preset-udemy-website@8.0.14) (2018-11-09)
 
 
@@ -14,7 +30,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-       <a name="8.0.13"></a>
+<a name="8.0.13"></a>
 ## [8.0.13](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@8.0.12...babel-preset-udemy-website@8.0.13) (2018-11-07)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "8.0.14",
+  "version": "9.0.0",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^5.0.5",
-    "eslint-config-udemy-website": "^7.1.10"
+    "eslint-config-udemy-basics": "^6.0.0",
+    "eslint-config-udemy-website": "^8.0.0"
   },
   "dependencies": {
     "@babel/plugin-external-helpers": "^7.0.0",

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^4.19.1",
+    "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^5.0.5",
     "eslint-config-udemy-website": "^7.1.10"
   },

--- a/packages/eslint-config-tester/CHANGELOG.md
+++ b/packages/eslint-config-tester/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.0.0"></a>
+# [1.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-tester@0.1.3...eslint-config-tester@1.0.0) (2018-11-09)
+
+
+### Features
+
+* Upgrade eslint to 5.x ([1655e2f](https://github.com/udemy/js-tooling/commit/1655e2f))
+
+
+### BREAKING CHANGES
+
+* Upgrade ESLint to ^5.9.0 and require node >=8.12.0 as an engine.
+
+
+
+
 <a name="0.1.3"></a>
 ## [0.1.3](https://github.com/udemy/js-tooling/compare/eslint-config-tester@0.1.2...eslint-config-tester@0.1.3) (2018-11-06)
 

--- a/packages/eslint-config-tester/package.json
+++ b/packages/eslint-config-tester/package.json
@@ -14,10 +14,10 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "peerDependencies": {
-    "eslint": "^4.19.1"
+    "eslint": "^5.9.0"
   },
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   }
 }

--- a/packages/eslint-config-tester/package.json
+++ b/packages/eslint-config-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tester",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "description": "ESLint configuration tester",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-babel-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-babel-addons/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="3.0.2"></a>
+ <a name="4.0.0"></a>
+# [4.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-babel-addons@3.0.2...eslint-config-udemy-babel-addons@4.0.0) (2018-11-09)
+
+
+### Features
+
+* Upgrade eslint to 5.x ([1655e2f](https://github.com/udemy/js-tooling/commit/1655e2f))
+
+
+### BREAKING CHANGES
+
+* Upgrade ESLint to ^5.9.0 and require node >=8.12.0 as an engine.
+
+
+
+
+ <a name="3.0.2"></a>
 ## [3.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-babel-addons@3.0.1...eslint-config-udemy-babel-addons@3.0.2) (2018-11-06)
 
 
@@ -14,7 +30,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-       <a name="3.0.1"></a>
+<a name="3.0.1"></a>
 ## [3.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-babel-addons@3.0.0...eslint-config-udemy-babel-addons@3.0.1) (2018-11-06)
 
 

--- a/packages/eslint-config-udemy-babel-addons/package.json
+++ b/packages/eslint-config-udemy-babel-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-babel-addons",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "Udemy's Babel related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -26,6 +26,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^0.1.3"
+    "eslint-config-tester": "^1.0.0"
   }
 }

--- a/packages/eslint-config-udemy-babel-addons/package.json
+++ b/packages/eslint-config-udemy-babel-addons/package.json
@@ -15,14 +15,14 @@
   },
   "dependencies": {
     "eslint-plugin-babel": "^5.2.1",
-    "eslint-plugin-import": "^2.8.0"
+    "eslint-plugin-import": "^2.14.0"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^4.19.1"
+    "eslint": "^5.9.0"
   },
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   },
   "devDependencies": {

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="5.0.5"></a>
+       <a name="6.0.0"></a>
+# [6.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@5.0.5...eslint-config-udemy-basics@6.0.0) (2018-11-09)
+
+
+### Features
+
+* Upgrade eslint to 5.x ([1655e2f](https://github.com/udemy/js-tooling/commit/1655e2f))
+
+
+### BREAKING CHANGES
+
+* Upgrade ESLint to ^5.9.0 and require node >=8.12.0 as an engine.
+
+
+
+
+       <a name="5.0.5"></a>
 ## [5.0.5](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@5.0.4...eslint-config-udemy-basics@5.0.5) (2018-11-06)
 
 
@@ -11,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-basics
 
- <a name="5.0.4"></a>
+<a name="5.0.4"></a>
 ## [5.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@5.0.3...eslint-config-udemy-basics@5.0.4) (2018-09-24)
 
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "5.0.5",
+  "version": "6.0.0",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -18,7 +18,7 @@
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import-order-alphabetical": "^0.0.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-udemy": "^6.0.4"
+    "eslint-plugin-udemy": "^7.0.0"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
@@ -29,6 +29,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^0.1.3"
+    "eslint-config-tester": "^1.0.0"
   }
 }

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -15,17 +15,17 @@
   },
   "dependencies": {
     "eslint-import-resolver-node": "^0.3.2",
-    "eslint-plugin-filenames": "^1.2.0",
+    "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import-order-alphabetical": "^0.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-udemy": "^6.0.4"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^4.19.1"
+    "eslint": "^5.9.0"
   },
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   },
   "devDependencies": {

--- a/packages/eslint-config-udemy-jasmine-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-jasmine-addons/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="5.0.1"></a>
+       <a name="6.0.0"></a>
+# [6.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-jasmine-addons@5.0.1...eslint-config-udemy-jasmine-addons@6.0.0) (2018-11-09)
+
+
+### Features
+
+* Upgrade eslint to 5.x ([1655e2f](https://github.com/udemy/js-tooling/commit/1655e2f))
+
+
+### BREAKING CHANGES
+
+* Upgrade ESLint to ^5.9.0 and require node >=8.12.0 as an engine.
+
+
+
+
+       <a name="5.0.1"></a>
 ## [5.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-jasmine-addons@5.0.0...eslint-config-udemy-jasmine-addons@5.0.1) (2018-11-06)
 
 
@@ -11,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-jasmine-addons
 
- <a name="5.0.0"></a>
+<a name="5.0.0"></a>
 # [5.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-jasmine-addons@3.1.10...eslint-config-udemy-jasmine-addons@5.0.0) (2018-06-29)
 
 

--- a/packages/eslint-config-udemy-jasmine-addons/package.json
+++ b/packages/eslint-config-udemy-jasmine-addons/package.json
@@ -14,14 +14,14 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "dependencies": {
-    "eslint-plugin-jasmine": "^2.9.1"
+    "eslint-plugin-jasmine": "^2.10.1"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^4.19.1"
+    "eslint": "^5.9.0"
   },
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   },
   "devDependencies": {

--- a/packages/eslint-config-udemy-jasmine-addons/package.json
+++ b/packages/eslint-config-udemy-jasmine-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-jasmine-addons",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Udemy's Jasmine related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -25,6 +25,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^0.1.3"
+    "eslint-config-tester": "^1.0.0"
   }
 }

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="5.0.2"></a>
+ <a name="6.0.0"></a>
+# [6.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@5.0.2...eslint-config-udemy-react-addons@6.0.0) (2018-11-09)
+
+
+### Features
+
+* Upgrade eslint to 5.x ([1655e2f](https://github.com/udemy/js-tooling/commit/1655e2f))
+
+
+### BREAKING CHANGES
+
+* Upgrade ESLint to ^5.9.0 and require node >=8.12.0 as an engine.
+
+
+
+
+ <a name="5.0.2"></a>
 ## [5.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@5.0.1...eslint-config-udemy-react-addons@5.0.2) (2018-11-06)
 
 
@@ -14,7 +30,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-       <a name="5.0.1"></a>
+<a name="5.0.1"></a>
 ## [5.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@5.0.0...eslint-config-udemy-react-addons@5.0.1) (2018-11-06)
 
 

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -26,6 +26,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^0.1.3"
+    "eslint-config-tester": "^1.0.0"
   }
 }

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -14,15 +14,15 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "dependencies": {
-    "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.9.1"
+    "eslint-plugin-jsx-a11y": "^6.1.2",
+    "eslint-plugin-react": "^7.11.1"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^4.19.1"
+    "eslint": "^5.9.0"
   },
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   },
   "devDependencies": {

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="7.1.10"></a>
+ <a name="8.0.0"></a>
+# [8.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.1.10...eslint-config-udemy-website@8.0.0) (2018-11-09)
+
+
+### Features
+
+* Upgrade eslint to 5.x ([1655e2f](https://github.com/udemy/js-tooling/commit/1655e2f))
+
+
+### BREAKING CHANGES
+
+* Upgrade ESLint to ^5.9.0 and require node >=8.12.0 as an engine.
+
+
+
+
+ <a name="7.1.10"></a>
 ## [7.1.10](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.1.9...eslint-config-udemy-website@7.1.10) (2018-11-06)
 
 
@@ -11,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
-       <a name="7.1.9"></a>
+<a name="7.1.9"></a>
 ## [7.1.9](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@7.1.8...eslint-config-udemy-website@7.1.9) (2018-11-06)
 
 

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -19,16 +19,16 @@
     "eslint-config-udemy-jasmine-addons": "^5.0.1",
     "eslint-config-udemy-react-addons": "^5.0.2",
     "eslint-import-resolver-webpack": "^0.10.1",
-    "eslint-plugin-filenames": "^1.2.0",
-    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-filenames": "^1.3.2",
+    "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-underscore": "^0.0.10"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^4.19.1"
+    "eslint": "^5.9.0"
   },
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   },
   "devDependencies": {

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "7.1.10",
+  "version": "8.0.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -14,10 +14,10 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "dependencies": {
-    "eslint-config-udemy-babel-addons": "^3.0.2",
-    "eslint-config-udemy-basics": "^5.0.5",
-    "eslint-config-udemy-jasmine-addons": "^5.0.1",
-    "eslint-config-udemy-react-addons": "^5.0.2",
+    "eslint-config-udemy-babel-addons": "^4.0.0",
+    "eslint-config-udemy-basics": "^6.0.0",
+    "eslint-config-udemy-jasmine-addons": "^6.0.0",
+    "eslint-config-udemy-react-addons": "^6.0.0",
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.14.0",
@@ -32,6 +32,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^0.1.3"
+    "eslint-config-tester": "^1.0.0"
   }
 }

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="6.0.4"></a>
+ <a name="7.0.0"></a>
+# [7.0.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@6.0.4...eslint-plugin-udemy@7.0.0) (2018-11-09)
+
+
+### Features
+
+* Upgrade eslint to 5.x ([1655e2f](https://github.com/udemy/js-tooling/commit/1655e2f))
+
+
+### BREAKING CHANGES
+
+* Upgrade ESLint to ^5.9.0 and require node >=8.12.0 as an engine.
+
+
+
+
+ <a name="6.0.4"></a>
 ## [6.0.4](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@6.0.3...eslint-plugin-udemy@6.0.4) (2018-11-06)
 
 
@@ -11,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-plugin-udemy
 
-       <a name="6.0.3"></a>
+<a name="6.0.3"></a>
 ## [6.0.3](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@6.0.2...eslint-plugin-udemy@6.0.3) (2018-09-24)
 
 

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "6.0.4",
+  "version": "7.0.0",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {
@@ -16,7 +16,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-tester": "^0.1.3"
+    "eslint-config-tester": "^1.0.0"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -15,11 +15,11 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^4.19.1",
+    "eslint": "^5.9.0",
     "eslint-config-tester": "^0.1.3"
   },
   "engines": {
-    "node": ">=8.9.1",
+    "node": ">=8.12.0",
     "yarn": "^1.9.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,42 +653,23 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-acorn-jsx@^3.0.0:
-  version "3.0.1"
-  resolved "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
-  dependencies:
-    acorn "^3.0.4"
+acorn-jsx@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.0.tgz#958584ddb60990c02c97c1bd9d521fce433bb101"
 
-acorn@^3.0.4:
-  version "3.3.0"
-  resolved "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-
-acorn@^5.5.0:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+acorn@^6.0.2:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.4.tgz#77377e7353b72ec5104550aa2d2097a2fd40b754"
 
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
 
-ajv-keywords@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
-
 ajv-keywords@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
-ajv@^5.2.3, ajv@^5.3.0:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
-ajv@^6.5.0:
+ajv@^6.5.0, ajv@^6.5.3:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.5.tgz#cf97cdade71c6399a92c6d6c4177381291b781a1"
   dependencies:
@@ -844,14 +825,6 @@ axobject-query@^2.0.1:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
   dependencies:
     ast-types-flow "0.0.7"
-
-babel-code-frame@^6.22.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
 
 babel-eslint@^10.0.1:
   version "10.0.1"
@@ -1096,8 +1069,8 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-lite@^1.0.30000899:
-  version "1.0.30000906"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000906.tgz#7c44e498a2504f7a5db3b4f91285bbc821157a77"
+  version "1.0.30000907"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000907.tgz#0b9899bde53fb1c30e214fb12402361e02ff5c42"
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -1124,6 +1097,10 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
 chokidar@^2.0.3:
   version "2.0.4"
@@ -1158,6 +1135,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -1196,10 +1177,6 @@ cmd-shim@^2.0.2:
   dependencies:
     graceful-fs "^4.1.2"
     mkdirp "~0.5.0"
-
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -1256,7 +1233,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.10, concat-stream@^1.6.0:
+concat-stream@^1.4.10:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -1485,11 +1462,21 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^5.0.1, cross-spawn@^5.1.0:
+cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -1565,6 +1552,12 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
 debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
   dependencies:
     ms "^2.1.1"
 
@@ -1696,8 +1689,8 @@ duplexer@^0.1.1:
   resolved "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 electron-to-chromium@^1.3.82:
-  version "1.3.83"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz#74584eb0972bb6777811c5d68d988c722f5e6666"
+  version "1.3.84"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz#2e55df59e818f150a9f61b53471ebf4f0feecc65"
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -1790,7 +1783,7 @@ eslint-plugin-babel@^5.2.1:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
-eslint-plugin-filenames@^1.2.0:
+eslint-plugin-filenames@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz#7094f00d7aefdd6999e3ac19f72cea058e590cf7"
   dependencies:
@@ -1807,7 +1800,7 @@ eslint-plugin-import-order-alphabetical@^0.0.1:
     lodash "^4.17.4"
     resolve "^1.6.0"
 
-eslint-plugin-import@^2.8.0:
+eslint-plugin-import@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"
   dependencies:
@@ -1822,11 +1815,11 @@ eslint-plugin-import@^2.8.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
-eslint-plugin-jasmine@^2.9.1:
+eslint-plugin-jasmine@^2.10.1:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.10.1.tgz#5733b709e751f4bc40e31e1c16989bd2cdfbec97"
 
-eslint-plugin-jsx-a11y@^6.0.2:
+eslint-plugin-jsx-a11y@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz#69bca4890b36dcf0fe16dd2129d2d88b98f33f88"
   dependencies:
@@ -1843,7 +1836,7 @@ eslint-plugin-promise@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz#2d074b653f35a23d1ba89d8e976a985117d1c6a2"
 
-eslint-plugin-react@^7.9.1:
+eslint-plugin-react@^7.11.1:
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"
   dependencies:
@@ -1870,72 +1863,77 @@ eslint-scope@3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^3.7.1:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.19.1:
-  version "4.19.1"
-  resolved "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+eslint@^5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.9.0.tgz#b234b6d15ef84b5849c6de2af43195a2d59d408e"
   dependencies:
-    ajv "^5.3.0"
-    babel-code-frame "^6.22.0"
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.5.3"
     chalk "^2.1.0"
-    concat-stream "^1.6.0"
-    cross-spawn "^5.1.0"
-    debug "^3.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
     doctrine "^2.1.0"
-    eslint-scope "^3.7.1"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^3.5.4"
-    esquery "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
-    globals "^11.0.1"
-    ignore "^3.3.3"
+    globals "^11.7.0"
+    ignore "^4.0.6"
     imurmurhash "^0.1.4"
-    inquirer "^3.0.6"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.9.1"
+    inquirer "^6.1.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.12.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.2"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
     path-is-inside "^1.0.2"
     pluralize "^7.0.0"
     progress "^2.0.0"
-    regexpp "^1.0.1"
+    regexpp "^2.0.1"
     require-uncached "^1.0.3"
-    semver "^5.3.0"
+    semver "^5.5.1"
     strip-ansi "^4.0.0"
-    strip-json-comments "~2.0.1"
-    table "4.0.2"
-    text-table "~0.2.0"
+    strip-json-comments "^2.0.1"
+    table "^5.0.2"
+    text-table "^0.2.0"
 
-espree@^3.5.4:
-  version "3.5.4"
-  resolved "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+espree@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.1.0.tgz#728d5451e0fd156c04384a7ad89ed51ff54eb25f"
   dependencies:
-    acorn "^5.5.0"
-    acorn-jsx "^3.0.0"
+    acorn "^6.0.2"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
 
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
 
-esquery@^1.0.0:
+esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
@@ -2023,6 +2021,14 @@ external-editor@^2.0.4:
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
+external-editor@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -2035,10 +2041,6 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-fast-deep-equal@^1.0.0:
-  version "1.1.0"
-  resolved "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -2096,17 +2098,13 @@ find-up@^2.0.0, find-up@^2.1.0:
     locate-path "^2.0.0"
 
 flat-cache@^1.2.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.1.tgz#0c7e56264f2f2445836130f2db116b15aa726326"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.2.tgz#7f852d70be573dac874a4c4129d340a34fba7e65"
   dependencies:
+    circular-json "^0.3.1"
     del "^3.0.0"
-    flatted "^2.0.0"
     graceful-fs "^4.1.2"
     write "^0.2.1"
-
-flatted@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -2252,7 +2250,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.0.1, globals@^11.1.0:
+globals@^11.1.0, globals@^11.7.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
 
@@ -2381,7 +2379,7 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.4:
+iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -2401,9 +2399,9 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.3:
-  version "3.3.10"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -2442,7 +2440,7 @@ ini@^1.3.2, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-inquirer@^3.0.6, inquirer@^3.2.2:
+inquirer@^3.2.2:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
@@ -2457,6 +2455,24 @@ inquirer@^3.0.6, inquirer@^3.2.2:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -2641,7 +2657,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-resolvable@^1.0.0:
+is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
@@ -2707,11 +2723,7 @@ js-levenshtein@^1.1.3:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-
-js-yaml@^3.9.1:
+js-yaml@^3.12.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -2719,20 +2731,16 @@ js-yaml@^3.9.1:
     esprima "^4.0.0"
 
 jsesc@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
 
 jsesc@~0.5.0:
   version "0.5.0"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+  resolved "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
-
-json-schema-traverse@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -2979,7 +2987,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.17.10, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -3115,7 +3123,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -3221,6 +3229,10 @@ needle@^2.2.1:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
     sax "^1.2.4"
+
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
 "node-libs-browser@^1.0.0 || ^2.0.0":
   version "2.1.0"
@@ -3387,7 +3399,7 @@ os-browserify@^0.3.0:
 
 os-homedir@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  resolved "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
 os-locale@^2.0.0:
   version "2.1.0"
@@ -3399,7 +3411,7 @@ os-locale@^2.0.0:
 
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  resolved "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 osenv@^0.1.4:
   version "0.1.5"
@@ -3510,13 +3522,13 @@ path-exists@^3.0.0:
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  resolved "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
 path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -3884,9 +3896,9 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^1.0.1:
-  version "1.1.0"
-  resolved "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
 
 regexpu-core@^1.0.0:
   version "1.0.0"
@@ -3968,7 +3980,7 @@ require-main-filename@^1.0.1:
 
 require-uncached@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  resolved "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
@@ -4027,6 +4039,12 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
+rxjs@^6.1.0:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -4045,7 +4063,7 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
@@ -4290,13 +4308,13 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 strong-log-transformer@^1.0.6:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz#f7fb93758a69a571140181277eea0c2eb1301fa3"
+  resolved "http://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz#f7fb93758a69a571140181277eea0c2eb1301fa3"
   dependencies:
     byline "^5.0.0"
     duplexer "^0.1.1"
@@ -4320,14 +4338,12 @@ supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
-table@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
+table@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.1.0.tgz#69a54644f6f01ad1628f8178715b408dc6bf11f7"
   dependencies:
-    ajv "^5.2.3"
-    ajv-keywords "^2.1.0"
-    chalk "^2.1.0"
-    lodash "^4.17.4"
+    ajv "^6.5.3"
+    lodash "^4.17.10"
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
@@ -4336,8 +4352,8 @@ tapable@^0.1.8:
   resolved "http://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4"
 
 tar@^4:
-  version "4.4.7"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.7.tgz#14df45023ffdcd0c233befa2fc01ebb76ee39e7c"
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
@@ -4373,7 +4389,7 @@ text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
 
-text-table@~0.2.0:
+text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -4453,6 +4469,10 @@ trim-off-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
##### *To:*
@kevinzang 

##### *What:*
Now that we have node 8.12.0 across platforms, I am upgrading eslint to the latest (5.9.0).

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3646

##### *What did you test:*
Ran `yarn test`

##### *What dashboards will you be monitoring:*
None
