### PR TITLE
feat: Disalllow angular as a global keyword.

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="8.0.3"></a>
+ <a name="8.0.4"></a>
+## [8.0.4](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.3...babel-polyfill-udemy-website@8.0.4) (2018-12-05)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+ <a name="8.0.3"></a>
 ## [8.0.3](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.2...babel-polyfill-udemy-website@8.0.3) (2018-11-28)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
-       <a name="8.0.2"></a>
+<a name="8.0.2"></a>
 ## [8.0.2](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.1...babel-polyfill-udemy-website@8.0.2) (2018-11-27)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^6.0.3",
-    "eslint-config-udemy-website": "^8.0.3"
+    "eslint-config-udemy-website": "^9.0.0"
   },
   "dependencies": {
     "@babel/cli": "^7.1.2",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="9.0.3"></a>
+ <a name="9.0.4"></a>
+## [9.0.4](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.3...babel-preset-udemy-website@9.0.4) (2018-12-05)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+ <a name="9.0.3"></a>
 ## [9.0.3](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.2...babel-preset-udemy-website@9.0.3) (2018-11-28)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
-       <a name="9.0.2"></a>
+<a name="9.0.2"></a>
 ## [9.0.2](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.1...babel-preset-udemy-website@9.0.2) (2018-11-27)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^6.0.3",
-    "eslint-config-udemy-website": "^8.0.3"
+    "eslint-config-udemy-website": "^9.0.0"
   },
   "dependencies": {
     "@babel/plugin-external-helpers": "^7.0.0",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="8.0.3"></a>
+ <a name="9.0.0"></a>
+# [9.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@8.0.3...eslint-config-udemy-website@9.0.0) (2018-12-05)
+
+
+### Features
+
+* Disalllow angular as a global keyword. ([177a98a](https://github.com/udemy/js-tooling/commit/177a98a))
+
+
+### BREAKING CHANGES
+
+* We no longer allow "angular" global keyword. Users need to `import angular from "angular";` in order to use `angular`.
+
+
+
+
+ <a name="8.0.3"></a>
 ## [8.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@8.0.2...eslint-config-udemy-website@8.0.3) (2018-11-28)
 
 
@@ -11,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
-       <a name="8.0.2"></a>
+<a name="8.0.2"></a>
 ## [8.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@8.0.1...eslint-config-udemy-website@8.0.2) (2018-11-27)
 
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -122,7 +122,6 @@ module.exports = {
         UD: true,
         module: false,
         inject: false,
-        angular: false,
         gettext: false,
         ngettext: false,
         npgettext: false,

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "8.0.3",
+  "version": "9.0.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@udemy/team-f 

##### *What:*
BREAKING CHANGE: We no longer allow "angular" global keyword. Users need to `import angular from "angular";` in order to use `angular`. To be released in conjunction with https://github.com/udemy/website-django/pull/30428 

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3673

##### *What did you test:*
Nothing

##### *What dashboards will you be monitoring:*
None
