### PR TITLE
Disallow JSX <img> tag.

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="8.0.4"></a>
+       <a name="8.0.5"></a>
+## [8.0.5](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.4...babel-polyfill-udemy-website@8.0.5) (2018-12-10)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+       <a name="8.0.4"></a>
 ## [8.0.4](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.3...babel-polyfill-udemy-website@8.0.4) (2018-12-05)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
- <a name="8.0.3"></a>
+<a name="8.0.3"></a>
 ## [8.0.3](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.2...babel-polyfill-udemy-website@8.0.3) (2018-11-28)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^6.0.3",
-    "eslint-config-udemy-website": "^9.0.0"
+    "eslint-config-udemy-website": "^9.0.1"
   },
   "dependencies": {
     "@babel/cli": "^7.1.2",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="9.0.4"></a>
+       <a name="9.0.5"></a>
+## [9.0.5](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.4...babel-preset-udemy-website@9.0.5) (2018-12-10)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+       <a name="9.0.4"></a>
 ## [9.0.4](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.3...babel-preset-udemy-website@9.0.4) (2018-12-05)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
- <a name="9.0.3"></a>
+<a name="9.0.3"></a>
 ## [9.0.3](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.2...babel-preset-udemy-website@9.0.3) (2018-11-28)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^6.0.3",
-    "eslint-config-udemy-website": "^9.0.0"
+    "eslint-config-udemy-website": "^9.0.1"
   },
   "dependencies": {
     "@babel/plugin-external-helpers": "^7.0.0",

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,7 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="6.0.0"></a>
+       <a name="7.0.0"></a>
+# [7.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@6.0.0...eslint-config-udemy-react-addons@7.0.0) (2018-12-10)
+
+
+* Disallow JSX <img> tag. ([2f91708](https://github.com/udemy/js-tooling/commit/2f91708))
+
+
+### BREAKING CHANGES
+
+* We no longer allow `<img>` tag on JSX. Users need to rely on `<Image>` base component.
+
+
+
+
+       <a name="6.0.0"></a>
 # [6.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@5.0.2...eslint-config-udemy-react-addons@6.0.0) (2018-11-09)
 
 
@@ -19,7 +33,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
- <a name="5.0.2"></a>
+<a name="5.0.2"></a>
 ## [5.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@5.0.1...eslint-config-udemy-react-addons@5.0.2) (2018-11-06)
 
 

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-react-addons/parts/react.js
+++ b/packages/eslint-config-udemy-react-addons/parts/react.js
@@ -5,6 +5,8 @@ module.exports = {
     rules: {
         // specify whether double or single quotes should be used in JSX attributes
         'jsx-quotes': ['error', 'prefer-double'],
+        // disallow <img> tags in JSX
+        'react/forbid-elements': ['error', { forbid: ['img'] }],
         // enforce boolean attributes notation in JSX
         'react/jsx-boolean-value': ['error', 'never'],
         // enforce or disallow spaces inside of curly braces in JSX attributes

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="9.0.0"></a>
+       <a name="9.0.1"></a>
+## [9.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@9.0.0...eslint-config-udemy-website@9.0.1) (2018-12-10)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
+       <a name="9.0.0"></a>
 # [9.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@8.0.3...eslint-config-udemy-website@9.0.0) (2018-12-05)
 
 
@@ -19,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
- <a name="8.0.3"></a>
+<a name="8.0.3"></a>
 ## [8.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@8.0.2...eslint-config-udemy-website@8.0.3) (2018-11-28)
 
 

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -17,7 +17,7 @@
     "eslint-config-udemy-babel-addons": "^4.0.0",
     "eslint-config-udemy-basics": "^6.0.3",
     "eslint-config-udemy-jasmine-addons": "^6.0.0",
-    "eslint-config-udemy-react-addons": "^6.0.0",
+    "eslint-config-udemy-react-addons": "^7.0.0",
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
##### *To:*
@udemy/team-f 

##### *What:*
Moving the <img> tag rule defined at https://github.com/udemy/website-django/pull/30724 into js-tooling. BREAKING CHANGE: We no longer allow `<img>` tag on JSX. Users need to rely on `<Image>` base component. I will merge this once tests pass.

##### *JIRA:*
Part of https://udemyjira.atlassian.net/browse/TF-52

##### *What did you test:*
Nothing

##### *What dashboards will you be monitoring:*
None
