### PR TITLE
Allow camelcased deprecated lifecycle methods prepended with UNSAFE

### DIFF
--- a/packages/eslint-config-udemy-basics/parts/stylistic-issues.js
+++ b/packages/eslint-config-udemy-basics/parts/stylistic-issues.js
@@ -10,7 +10,10 @@ module.exports = {
         // enforce one true brace style
         'brace-style': ['error', '1tbs', { allowSingleLine: true }],
         // require camel case names
-        camelcase: ['error', { properties: 'never' }],
+        camelcase: ['error', {
+            properties: 'never',
+            allow: ['UNSAFE_componentWillMount', 'UNSAFE_componentWillReceiveProps', 'UNSAFE_componentWillUpdate'],
+        }],
         // allow trailing commas in multiline object literals
         'comma-dangle': ['error', 'always-multiline'],
         // enforce spacing after comma


### PR DESCRIPTION
##### *To:*
@udemy/team-f 

##### *What:*
In order to upgrade React past version 16.3, the [react/no-unsafe](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unsafe.md) eslint rule must be satisfied.

However, that rule conflicts with [camelcase](https://eslint.org/docs/rules/camelcase) without providing the `allow` option to the rule.

This PR configures the camelcase rule to allow certain `UNSAFE_` prefixed deprecated React component lifecycle methods to be exempt.

Reference: https://github.com/eslint/eslint/pull/10783

React 16.7 Upgrade PR: https://github.com/udemy/website-django/pull/31054

##### *JIRA:*
<Link to the JIRA issue for this PR or use the JIRA-Github integration and remove this>

##### *What did you test:*
<Any manual testing you've done in addition to the automated tests>

##### *What dashboards will you be monitoring:*
<Link to the dashboards (https://app.datadoghq.com/dash/list) you'll monitor when you release>
