### PR TITLE
TF-3712 Disallow inject as global

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="8.0.5"></a>
+ <a name="8.0.6"></a>
+## [8.0.6](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.5...babel-polyfill-udemy-website@8.0.6) (2019-01-03)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+ <a name="8.0.5"></a>
 ## [8.0.5](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.4...babel-polyfill-udemy-website@8.0.5) (2018-12-10)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
-       <a name="8.0.4"></a>
+<a name="8.0.4"></a>
 ## [8.0.4](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.3...babel-polyfill-udemy-website@8.0.4) (2018-12-05)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^6.0.3",
-    "eslint-config-udemy-website": "^9.0.1"
+    "eslint-config-udemy-website": "^10.0.0"
   },
   "dependencies": {
     "@babel/cli": "^7.1.2",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="9.0.5"></a>
+ <a name="9.0.6"></a>
+## [9.0.6](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.5...babel-preset-udemy-website@9.0.6) (2019-01-03)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+ <a name="9.0.5"></a>
 ## [9.0.5](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.4...babel-preset-udemy-website@9.0.5) (2018-12-10)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
-       <a name="9.0.4"></a>
+<a name="9.0.4"></a>
 ## [9.0.4](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.3...babel-preset-udemy-website@9.0.4) (2018-12-05)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^6.0.3",
-    "eslint-config-udemy-website": "^9.0.1"
+    "eslint-config-udemy-website": "^10.0.0"
   },
   "dependencies": {
     "@babel/plugin-external-helpers": "^7.0.0",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="9.0.1"></a>
+ <a name="10.0.0"></a>
+# [10.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@9.0.1...eslint-config-udemy-website@10.0.0) (2019-01-03)
+
+
+### Bug Fixes
+
+* disallow inject as global ([139d514](https://github.com/udemy/js-tooling/commit/139d514))
+
+
+### BREAKING CHANGES
+
+* inject is no longer accepted as a global. previously, we accepted it in angularjs specs, but it is problematic because ESLint doesn't complain when we use inject from mobx without importing it. fix angularjs specs via `import mocks from 'angularMocks'; mocks.inject`.
+
+
+
+
+ <a name="9.0.1"></a>
 ## [9.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@9.0.0...eslint-config-udemy-website@9.0.1) (2018-12-10)
 
 
@@ -11,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
-       <a name="9.0.0"></a>
+<a name="9.0.0"></a>
 # [9.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@8.0.3...eslint-config-udemy-website@9.0.0) (2018-12-05)
 
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -121,7 +121,6 @@ module.exports = {
     globals: {
         UD: true,
         module: false,
-        inject: false,
         gettext: false,
         ngettext: false,
         npgettext: false,

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@udemy/team-f 

##### *What:*
Disallow inject as global.

BREAKING CHANGE: inject is no longer accepted as a global. Previously, we accepted it in angularjs specs, but it is problematic because ESLint doesn't complain when we use inject from mobx without importing it. fix angularjs specs via `import mocks from 'angularMocks'; mocks.inject`. See https://github.com/udemy/website-django/pull/31162.

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3712

##### *What did you test:*
I applied the change manually in website-django and fixed the lint errors in https://github.com/udemy/website-django/pull/31162.

##### *What dashboards will you be monitoring:*
None
