### PR TITLE
TF-3720 Add udemy/no-hardcoded-cdns

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="8.0.6"></a>
+       <a name="8.0.7"></a>
+## [8.0.7](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.6...babel-polyfill-udemy-website@8.0.7) (2019-01-10)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+       <a name="8.0.6"></a>
 ## [8.0.6](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.5...babel-polyfill-udemy-website@8.0.6) (2019-01-03)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
- <a name="8.0.5"></a>
+<a name="8.0.5"></a>
 ## [8.0.5](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@8.0.4...babel-polyfill-udemy-website@8.0.5) (2018-12-10)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "8.0.6",
+  "version": "8.0.7",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^6.0.3",
-    "eslint-config-udemy-website": "^10.0.0"
+    "eslint-config-udemy-basics": "^6.0.4",
+    "eslint-config-udemy-website": "^10.1.0"
   },
   "dependencies": {
     "@babel/cli": "^7.1.2",

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="9.0.6"></a>
+       <a name="9.0.7"></a>
+## [9.0.7](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.6...babel-preset-udemy-website@9.0.7) (2019-01-10)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+       <a name="9.0.6"></a>
 ## [9.0.6](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.5...babel-preset-udemy-website@9.0.6) (2019-01-03)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
- <a name="9.0.5"></a>
+<a name="9.0.5"></a>
 ## [9.0.5](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@9.0.4...babel-preset-udemy-website@9.0.5) (2018-12-10)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "9.0.6",
+  "version": "9.0.7",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^6.0.3",
-    "eslint-config-udemy-website": "^10.0.0"
+    "eslint-config-udemy-basics": "^6.0.4",
+    "eslint-config-udemy-website": "^10.1.0"
   },
   "dependencies": {
     "@babel/plugin-external-helpers": "^7.0.0",

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="6.0.3"></a>
+       <a name="6.0.4"></a>
+## [6.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@6.0.3...eslint-config-udemy-basics@6.0.4) (2019-01-10)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
+       <a name="6.0.3"></a>
 ## [6.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@6.0.2...eslint-config-udemy-basics@6.0.3) (2018-11-28)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-basics
 
- <a name="6.0.2"></a>
+<a name="6.0.2"></a>
 ## [6.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@6.0.1...eslint-config-udemy-basics@6.0.2) (2018-11-27)
 
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -18,7 +18,7 @@
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import-order-alphabetical": "^0.0.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-udemy": "^8.0.0"
+    "eslint-plugin-udemy": "^8.1.0"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="10.0.0"></a>
+       <a name="10.1.0"></a>
+# [10.1.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@10.0.0...eslint-config-udemy-website@10.1.0) (2019-01-10)
+
+
+### Features
+
+* Add udemy/no-hardcoded-cdns ([daf4226](https://github.com/udemy/js-tooling/commit/daf4226))
+
+
+
+
+       <a name="10.0.0"></a>
 # [10.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@9.0.1...eslint-config-udemy-website@10.0.0) (2019-01-03)
 
 
@@ -19,7 +30,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
- <a name="9.0.1"></a>
+<a name="9.0.1"></a>
 ## [9.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@9.0.0...eslint-config-udemy-website@9.0.1) (2018-12-10)
 
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -104,6 +104,16 @@ module.exports = {
             },
         ]],
         'udemy/no-action-bound': ['error', 'always'],
+        'udemy/no-hardcoded-cdns': ['error', [
+            {
+                cdn: 'udemy-images.udemy.com',
+                fixWith: 'udLink.toS3Images()',
+            },
+            {
+                cdn: 's3.amazonaws.com/udemy-images',
+                fixWith: 'udLink.toS3Images()',
+            },
+        ]],
         'underscore/prefer-noop': ['error', 'always'],
     },
     overrides: [

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "eslint-config-udemy-babel-addons": "^4.0.0",
-    "eslint-config-udemy-basics": "^6.0.3",
+    "eslint-config-udemy-basics": "^6.0.4",
     "eslint-config-udemy-jasmine-addons": "^6.0.0",
     "eslint-config-udemy-react-addons": "^7.0.0",
     "eslint-import-resolver-webpack": "^0.10.1",

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,7 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="8.0.0"></a>
+ <a name="8.1.0"></a>
+# [8.1.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@8.0.0...eslint-plugin-udemy@8.1.0) (2019-01-10)
+
+
+### Features
+
+* Add udemy/no-hardcoded-cdns ([daf4226](https://github.com/udemy/js-tooling/commit/daf4226))
+
+
+
+
+ <a name="8.0.0"></a>
 # [8.0.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@7.0.2...eslint-plugin-udemy@8.0.0) (2018-11-28)
 
 
@@ -19,7 +30,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-       <a name="7.0.2"></a>
+<a name="7.0.2"></a>
 ## [7.0.2](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@7.0.1...eslint-plugin-udemy@7.0.2) (2018-11-27)
 
 

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {

--- a/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/README.md
+++ b/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/README.md
@@ -1,0 +1,35 @@
+# No Hardcoded CDNs
+
+`udemy/no-hardcoded-cdns` forbids hardcoding CDNs in urls. Instead, the CDN should be passed from backend to frontend through UD.Config. This makes it easier to migrate our CDNs.
+
+## Rule details
+
+The blacklist is configured by a list of `{cdn, fixWith}` objects. The `cdn` is the name of the CDN to forbid. The `fixWith` is the code that should be used instead of hardcoding the CDN.
+
+Assuming the following configuration:
+
+```js
+'udemy/no-hardcoded-cdns': ['error', [
+    {
+        cdn: 'udemy-images.udemy.com',
+        fixWith: 'udLink.toS3Images()',
+    },
+]]
+```
+
+The following would error:
+
+```js 
+'https://udemy-images.udemy.com/user/123/abc.png'
+`https://udemy-images.udemy.com/user/${user.id}/abc.png`
+```
+
+The following would not error:
+
+```js
+// This outsmarts the rule, but please don't do this!
+['https://udemy-images', 'udemy', 'com'].join('.') + '/user/123/abc.png'
+
+// This is the correct way.
+udLink.toS3Images('user/123/abc.png')
+```

--- a/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/index.js
+++ b/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+module.exports.rules = {
+    'no-hardcoded-cdns': {
+        meta: {
+            schema: [{
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        cdn: {
+                            type: 'string',
+                        },
+                        fixWith: {
+                            type: 'string',
+                        },
+                    },
+                    required: ['cdn', 'fixWith'],
+                },
+            }],
+        },
+        create(context) {
+            const cdns = context.options[0] || [];
+            const sourceCode = context.getSourceCode();
+
+            function checkForCDNs(string, currentNode) {
+                cdns.forEach(({ cdn, fixWith }) => {
+                    if (string.includes(cdn)) {
+                        context.report({
+                            node: currentNode,
+                            message: (
+                                `Please do not hardcode the CDN ${cdn}. ` +
+                                `Instead, build the url with ${fixWith}.`
+                            ),
+                        });
+                    }
+                });
+            }
+
+            return {
+                TemplateLiteral(node) {
+                    checkForCDNs(sourceCode.getText(node), node);
+                },
+                Literal(node) {
+                    if (node.value && typeof node.value === 'string') {
+                        checkForCDNs(node.value, node);
+                    }
+                },
+            };
+        },
+    },
+};

--- a/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/tests.js
+++ b/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/tests.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+
+const rule = require('./index').rules['no-hardcoded-cdns'];
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2015,
+        sourceType: 'module',
+    },
+});
+
+const options = [[
+    {
+        cdn: 'udemy-images.udemy.com',
+        fixWith: 'udLink.toS3Images()',
+    },
+]];
+
+ruleTester.run('no-hardcoded-cdns', rule, {
+    valid: [
+        {
+            code: "udLink.toS3Images('user/123/foo.png')",
+            options,
+        },
+        {
+            code: '// We used to use udemy-images.udemy.com for S3 images.',
+            options,
+        },
+    ],
+    invalid: [
+        {
+            code: "'https://udemy-images.udemy.com/user/123/foo.png'",
+            errors: [{ message: 'Please do not hardcode the CDN udemy-images.udemy.com. Instead, build the url with udLink.toS3Images().' }],
+            options,
+        },
+        {
+            // eslint-disable-next-line no-template-curly-in-string
+            code: '`https://udemy-images.udemy.com/user/${user.id}/foo.png`',
+            errors: [{ message: 'Please do not hardcode the CDN udemy-images.udemy.com. Instead, build the url with udLink.toS3Images().' }],
+            options,
+        },
+    ],
+});


### PR DESCRIPTION
##### *To:*
@cansin @udemy/team-f 

##### *What:*
Add udemy/no-hardcoded-cdns. To be released with or after https://github.com/udemy/website-django/pull/31321. To facilitate the stream team's CDN migration, add an ESLint rule preventing hardcoded CDNs.

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3720

##### *What did you test:*
I added the rule manually to website-django and used it to find all the hardcoded instances of udemy-images.udemy.com that https://github.com/udemy/website-django/pull/31321 is replacing.

##### *What dashboards will you be monitoring:*
None
