### PR TITLE
Fix: linter should force to put boolean value instead of omitting tru…

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="9.0.2"></a>
+       <a name="9.0.3"></a>
+## [9.0.3](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.2...babel-polyfill-udemy-website@9.0.3) (2019-02-28)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+       <a name="9.0.2"></a>
 ## [9.0.2](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.1...babel-polyfill-udemy-website@9.0.2) (2019-01-28)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
- <a name="9.0.1"></a>
+<a name="9.0.1"></a>
 ## [9.0.1](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.0...babel-polyfill-udemy-website@9.0.1) (2019-01-28)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^8.0.1",
-    "eslint-config-udemy-website": "^12.0.1",
+    "eslint-config-udemy-website": "^12.0.2",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="10.0.2"></a>
+       <a name="10.0.3"></a>
+## [10.0.3](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@10.0.2...babel-preset-udemy-website@10.0.3) (2019-02-28)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+       <a name="10.0.2"></a>
 ## [10.0.2](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@10.0.1...babel-preset-udemy-website@10.0.2) (2019-01-28)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
- <a name="10.0.1"></a>
+<a name="10.0.1"></a>
 ## [10.0.1](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@10.0.0...babel-preset-udemy-website@10.0.1) (2019-01-28)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^8.0.1",
-    "eslint-config-udemy-website": "^12.0.1",
+    "eslint-config-udemy-website": "^12.0.2",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,7 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="9.0.0"></a>
+ <a name="10.0.0"></a>
+# [10.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@9.0.0...eslint-config-udemy-react-addons@10.0.0) (2019-02-28)
+
+
+### Bug Fixes
+
+* react/jsx-boolean-value - put "always" option instead of "never". ([9630e3a](https://github.com/udemy/js-tooling/commit/9630e3a))
+
+
+### BREAKING CHANGES
+
+* explicit true is now required for boolean prop values.
+
+
+
+
+ <a name="9.0.0"></a>
 # [9.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@8.0.0...eslint-config-udemy-react-addons@9.0.0) (2019-01-28)
 
 
@@ -19,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-       <a name="8.0.0"></a>
+<a name="8.0.0"></a>
 # [8.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@7.0.0...eslint-config-udemy-react-addons@8.0.0) (2019-01-28)
 
 

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-react-addons/parts/react.js
+++ b/packages/eslint-config-udemy-react-addons/parts/react.js
@@ -6,7 +6,7 @@ module.exports = {
         // disallow <img> tags in JSX
         'react/forbid-elements': ['error', {forbid: ['img']}],
         // enforce boolean attributes notation in JSX
-        'react/jsx-boolean-value': ['error', 'never'],
+        'react/jsx-boolean-value': ['error', 'always'],
         // prevent usage of .bind() in JSX props
         'react/jsx-no-bind': [
             'error',

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="12.0.1"></a>
+       <a name="12.0.2"></a>
+## [12.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.1...eslint-config-udemy-website@12.0.2) (2019-02-28)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
+       <a name="12.0.1"></a>
 ## [12.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.0...eslint-config-udemy-website@12.0.1) (2019-01-28)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
- <a name="12.0.0"></a>
+<a name="12.0.0"></a>
 # [12.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@11.0.0...eslint-config-udemy-website@12.0.0) (2019-01-28)
 
 

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -17,7 +17,7 @@
     "eslint-config-udemy-babel-addons": "^6.0.0",
     "eslint-config-udemy-basics": "^8.0.1",
     "eslint-config-udemy-jasmine-addons": "^8.0.0",
-    "eslint-config-udemy-react-addons": "^9.0.0",
+    "eslint-config-udemy-react-addons": "^10.0.0",
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION

##### *To:*
@udemy/team-f 
@kevinzang 
@jjinux 

##### *What:*
It's recommended by official ReactJS doc to always put boolean values for properties
https://reactjs.org/docs/jsx-in-depth.html#props-default-to-true
So we need to change linter rule to check it

