### PR TITLE
TF-3779 add _, isocompoent, .eslintrc, *.stories, and *.config to regex

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="9.0.3"></a>
+ <a name="9.0.4"></a>
+## [9.0.4](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.3...babel-polyfill-udemy-website@9.0.4) (2019-05-07)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+ <a name="9.0.3"></a>
 ## [9.0.3](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.2...babel-polyfill-udemy-website@9.0.3) (2019-02-28)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
-       <a name="9.0.2"></a>
+<a name="9.0.2"></a>
 ## [9.0.2](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.1...babel-polyfill-udemy-website@9.0.2) (2019-01-28)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^8.0.1",
-    "eslint-config-udemy-website": "^12.0.2",
+    "eslint-config-udemy-website": "^12.0.3",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="11.0.0"></a>
+ <a name="11.0.1"></a>
+## [11.0.1](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.0...babel-preset-udemy-website@11.0.1) (2019-05-07)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+ <a name="11.0.0"></a>
 # [11.0.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@10.1.0...babel-preset-udemy-website@11.0.0) (2019-04-25)
 
 
@@ -19,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-       <a name="10.1.0"></a>
+<a name="10.1.0"></a>
 # [10.1.0](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@10.0.3...babel-preset-udemy-website@10.1.0) (2019-03-14)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^8.0.1",
-    "eslint-config-udemy-website": "^12.0.2",
+    "eslint-config-udemy-website": "^12.0.3",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="12.0.2"></a>
+ <a name="12.0.3"></a>
+## [12.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.2...eslint-config-udemy-website@12.0.3) (2019-05-07)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
+ <a name="12.0.2"></a>
 ## [12.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.1...eslint-config-udemy-website@12.0.2) (2019-02-28)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
-       <a name="12.0.1"></a>
+<a name="12.0.1"></a>
 ## [12.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.0...eslint-config-udemy-website@12.0.1) (2019-01-28)
 
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -16,7 +16,19 @@ module.exports = {
     rules: {
         'filenames/match-regex': [
             'error',
-            '^(?:[a-z0-9\\-]+(?:\\.(?:ng-(?:constant|controller|directive|factory|filter|provider|service)|videojs-component|react-(?:component|proptypes)|mobx-(?:model|store)))?(?:\\.spec)?)$',
+            [
+                [
+                    '^(?:_?[a-z0-9\\-]+', // allows underscore start and any lowercase filename
+                    '(?:\\.(?:', // any dot must be:
+                    'ng-(?:constant|controller|directive|factory|filter|provider|service)', // an Angular file
+                    '|videojs-component', // or a videojs-compenent
+                    '|react-(?:isocomponent|component|proptypes)', // or a React file
+                    '|mobx-(?:model|store)))?', // or a Mobx file
+                    '(?:\\.spec)?)$', // allows group to be a spec file
+                ].join(''),
+                '|^\\.eslintrc$', // files named .eslintrc.js
+                '|^[a-z0-9\\-]+\\.config$', // files named *.config.js
+            ].join(''),
         ],
         'udemy/angular-path-based-module-names': ['error', 'always'],
         'udemy/decorator-order': ['error', 'always'],

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -27,7 +27,7 @@ module.exports = {
                     '(?:\\.spec)?)$', // allows group to be a spec file
                 ].join(''),
                 '|^\\.eslintrc$', // files named .eslintrc.js
-                '|^[a-z0-9\\-]+\\.config$', // files named *.config.js
+                '|^[a-z0-9\\-]+\\.(?:config|stories)$', // files named *.config.js or *.stories.js
             ].join(''),
         ],
         'udemy/angular-path-based-module-names': ['error', 'always'],

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -21,9 +21,10 @@ module.exports = {
                     '^(?:_?[a-z0-9\\-]+', // allows underscore start and any lowercase filename
                     '(?:\\.(?:', // any dot must be:
                     'ng-(?:constant|controller|directive|factory|filter|provider|service)', // an Angular file
-                    '|videojs-component', // or a videojs-compenent
+                    '|videojs-component', // or a videojs-component
                     '|react-(?:isocomponent|component|proptypes)', // or a React file
-                    '|mobx-(?:model|store)))?', // or a Mobx file
+                    '|mobx-(?:model|store)', // or a Mobx file
+                    '))?',
                     '(?:\\.spec)?)$', // allows group to be a spec file
                 ].join(''),
                 '|^\\.eslintrc$', // files named .eslintrc.js

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "12.0.2",
+  "version": "12.0.3",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@kevinzang @udemy/team-f @inancsevinc

##### *What:*
This adds adds:
   - Allow a leading underscore in the filename, e.g. _my-private-
   - Allow .react-isocomponent.js, .react-isocomponent.spec.js
   - Allow .eslintrc.js, *.config.js, *.stories.js

I also broke up the already long regex into joins for commenting.

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3779

##### *What did you test:*
Added changes to static/src/.eslintrc.js and removed disables in *.react-isocomponent.js, .eslintrc.js, *.config.js and ran:
TIMING=1 yarn lint
I also created some misnamed files and they seemed to be caught.

##### *What dashboards will you be monitoring:*
N/A