### PR TITLE
Force npm version update for changes in PR 69

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="9.0.6"></a>
+       <a name="9.0.7"></a>
+## [9.0.7](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.6...babel-polyfill-udemy-website@9.0.7) (2019-05-20)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+       <a name="9.0.6"></a>
 ## [9.0.6](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.5...babel-polyfill-udemy-website@9.0.6) (2019-05-20)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
- <a name="9.0.5"></a>
+<a name="9.0.5"></a>
 ## [9.0.5](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.4...babel-polyfill-udemy-website@9.0.5) (2019-05-08)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "9.0.6",
+  "version": "9.0.7",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^8.0.2",
-    "eslint-config-udemy-website": "^12.0.5",
+    "eslint-config-udemy-basics": "^8.0.3",
+    "eslint-config-udemy-website": "^12.0.6",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="11.0.3"></a>
+       <a name="11.0.4"></a>
+## [11.0.4](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.3...babel-preset-udemy-website@11.0.4) (2019-05-20)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+       <a name="11.0.3"></a>
 ## [11.0.3](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.2...babel-preset-udemy-website@11.0.3) (2019-05-20)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
- <a name="11.0.2"></a>
+<a name="11.0.2"></a>
 ## [11.0.2](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.1...babel-preset-udemy-website@11.0.2) (2019-05-08)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^8.0.2",
-    "eslint-config-udemy-website": "^12.0.5",
+    "eslint-config-udemy-basics": "^8.0.3",
+    "eslint-config-udemy-website": "^12.0.6",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="8.0.2"></a>
+ <a name="8.0.3"></a>
+## [8.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@8.0.2...eslint-config-udemy-basics@8.0.3) (2019-05-20)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
+ <a name="8.0.2"></a>
 ## [8.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@8.0.1...eslint-config-udemy-basics@8.0.2) (2019-05-20)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-basics
 
-       <a name="8.0.1"></a>
+<a name="8.0.1"></a>
 ## [8.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@8.0.0...eslint-config-udemy-basics@8.0.1) (2019-01-28)
 
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-basics/parts/filenames.js
+++ b/packages/eslint-config-udemy-basics/parts/filenames.js
@@ -5,6 +5,7 @@ module.exports = {
     rules: {
         'filenames/match-regex': [
             'error',
+            // Allow config files, dash-cased JS files, and spec files.
             '^(?:\\.eslintrc|Gruntfile|prettier.config|[a-z0-9\\-]+(?:\\.spec)?)$',
         ],
     },

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="12.0.5"></a>
+       <a name="12.0.6"></a>
+## [12.0.6](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.5...eslint-config-udemy-website@12.0.6) (2019-05-20)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
+       <a name="12.0.5"></a>
 ## [12.0.5](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.4...eslint-config-udemy-website@12.0.5) (2019-05-20)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
- <a name="12.0.4"></a>
+<a name="12.0.4"></a>
 ## [12.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.3...eslint-config-udemy-website@12.0.4) (2019-05-08)
 
 

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "12.0.5",
+  "version": "12.0.6",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "eslint-config-udemy-babel-addons": "^6.0.0",
-    "eslint-config-udemy-basics": "^8.0.2",
+    "eslint-config-udemy-basics": "^8.0.3",
     "eslint-config-udemy-jasmine-addons": "^8.0.1",
     "eslint-config-udemy-react-addons": "^10.0.1",
     "eslint-import-resolver-webpack": "^0.10.1",


### PR DESCRIPTION
##### *To:*
@joecan 

##### *What:*
Force npm version update for changes in https://github.com/udemy/js-tooling/pull/69. I ran `lerna publish` on that PR, but because of `npm adduser` auth issues the changes did not actually publish to npm. This PR just adds a comment to eslint-config-udemy-basics/parts/filenames.js in order to trigger another `lerna publish`.

##### *JIRA:*
None

##### *What did you test:*
Nothing

##### *What dashboards will you be monitoring:*
None
