### PR TITLE
[TF-3790] add tapen only blacklist rules

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="9.0.8"></a>
+       <a name="9.0.9"></a>
+## [9.0.9](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.8...babel-polyfill-udemy-website@9.0.9) (2019-06-12)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+       <a name="9.0.8"></a>
 ## [9.0.8](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.7...babel-polyfill-udemy-website@9.0.8) (2019-05-29)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
- <a name="9.0.7"></a>
+<a name="9.0.7"></a>
 ## [9.0.7](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.6...babel-polyfill-udemy-website@9.0.7) (2019-05-20)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "9.0.8",
+  "version": "9.0.9",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^8.0.3",
-    "eslint-config-udemy-website": "^12.0.7",
+    "eslint-config-udemy-website": "^12.0.8",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="11.0.5"></a>
+       <a name="11.0.6"></a>
+## [11.0.6](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.5...babel-preset-udemy-website@11.0.6) (2019-06-12)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+       <a name="11.0.5"></a>
 ## [11.0.5](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.4...babel-preset-udemy-website@11.0.5) (2019-05-29)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
- <a name="11.0.4"></a>
+<a name="11.0.4"></a>
 ## [11.0.4](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.3...babel-preset-udemy-website@11.0.4) (2019-05-20)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "11.0.5",
+  "version": "11.0.6",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -21,7 +21,7 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
     "eslint-config-udemy-basics": "^8.0.3",
-    "eslint-config-udemy-website": "^12.0.7",
+    "eslint-config-udemy-website": "^12.0.8",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="12.0.7"></a>
+       <a name="12.0.8"></a>
+## [12.0.8](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.7...eslint-config-udemy-website@12.0.8) (2019-06-12)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
+       <a name="12.0.7"></a>
 ## [12.0.7](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.6...eslint-config-udemy-website@12.0.7) (2019-05-29)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
- <a name="12.0.6"></a>
+<a name="12.0.6"></a>
 ## [12.0.6](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.5...eslint-config-udemy-website@12.0.6) (2019-05-20)
 
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -120,6 +120,24 @@ module.exports = {
                         "not `import { Link } from 'react-router-dom';`.",
                     exceptions: ['base-components/link.react-component(?:\\.spec)?\\.js$'],
                 },
+                {
+                    // Tapen only lib
+                    source: '^react-table(?:\\.js)?$',
+                    message: 'react-table is only allowed in tapen',
+                    exceptions: ['tapen/.*?\\.js$'],
+                },
+                {
+                    // Tapen only lib
+                    source: '^react-treebeard(?:\\.js)?$',
+                    message: 'react-treebeard is only allowed in tapen',
+                    exceptions: ['tapen/.*?\\.js$'],
+                },
+                {
+                    // Tapen only lib
+                    source: '^vis-react(?:\\.js)?$',
+                    message: 'vis-react is only allowed in tapen',
+                    exceptions: ['tapen/.*?\\.js$'],
+                },
             ],
         ],
         'udemy/no-action-bound': ['error', 'always'],

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "12.0.7",
+  "version": "12.0.8",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@kevinzang @udemy/team-f @inancsevinc
##### *What:*
This adds 3 modules to the import-blacklist, which can only be imported from tapen.
##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3790
##### *What did you test:*
I copied this over src/eslintrc.js and ran `yarn lint`.
I also tried adding an import to an non-tapen library and eslint complained.
##### *What dashboards will you be monitoring:*
N/A