### PR TITLE
no-gettext-template eslint rule

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="9.0.9"></a>
+ <a name="9.0.10"></a>
+## [9.0.10](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.9...babel-polyfill-udemy-website@9.0.10) (2019-07-29)
+
+
+
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+ <a name="9.0.9"></a>
 ## [9.0.9](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.8...babel-polyfill-udemy-website@9.0.9) (2019-06-12)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-polyfill-udemy-website
 
-       <a name="9.0.8"></a>
+<a name="9.0.8"></a>
 ## [9.0.8](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.7...babel-polyfill-udemy-website@9.0.8) (2019-05-29)
 
 

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "9.0.9",
+  "version": "9.0.10",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^8.0.3",
-    "eslint-config-udemy-website": "^12.0.8",
+    "eslint-config-udemy-basics": "^8.0.4",
+    "eslint-config-udemy-website": "^12.0.9",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="11.0.6"></a>
+ <a name="11.0.7"></a>
+## [11.0.7](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.6...babel-preset-udemy-website@11.0.7) (2019-07-29)
+
+
+
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+ <a name="11.0.6"></a>
 ## [11.0.6](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.5...babel-preset-udemy-website@11.0.6) (2019-06-12)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package babel-preset-udemy-website
 
-       <a name="11.0.5"></a>
+<a name="11.0.5"></a>
 ## [11.0.5](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.4...babel-preset-udemy-website@11.0.5) (2019-05-29)
 
 

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "11.0.6",
+  "version": "11.0.7",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^8.0.3",
-    "eslint-config-udemy-website": "^12.0.8",
+    "eslint-config-udemy-basics": "^8.0.4",
+    "eslint-config-udemy-website": "^12.0.9",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="8.0.3"></a>
+       <a name="8.0.4"></a>
+## [8.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@8.0.3...eslint-config-udemy-basics@8.0.4) (2019-07-29)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
+       <a name="8.0.3"></a>
 ## [8.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@8.0.2...eslint-config-udemy-basics@8.0.3) (2019-05-20)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-basics
 
- <a name="8.0.2"></a>
+<a name="8.0.2"></a>
 ## [8.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@8.0.1...eslint-config-udemy-basics@8.0.2) (2019-05-20)
 
 

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -20,7 +20,7 @@
     "eslint-plugin-import-order-alphabetical": "^0.0.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-udemy": "^9.0.1"
+    "eslint-plugin-udemy": "^9.0.2"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-       <a name="12.0.8"></a>
+ <a name="12.0.9"></a>
+## [12.0.9](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.8...eslint-config-udemy-website@12.0.9) (2019-07-29)
+
+
+
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
+ <a name="12.0.8"></a>
 ## [12.0.8](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.7...eslint-config-udemy-website@12.0.8) (2019-06-12)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-config-udemy-website
 
-       <a name="12.0.7"></a>
+<a name="12.0.7"></a>
 ## [12.0.7](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.6...eslint-config-udemy-website@12.0.7) (2019-05-29)
 
 

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -141,6 +141,7 @@ module.exports = {
             ],
         ],
         'udemy/no-action-bound': ['error', 'always'],
+        'udemy/no-gettext-template': ['error', 'always'],
         'udemy/no-hardcoded-cdns': [
             'error',
             [

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -141,7 +141,7 @@ module.exports = {
             ],
         ],
         'udemy/no-action-bound': ['error', 'always'],
-        'udemy/no-gettext-template': ['error', 'always'],
+        'udemy/no-gettext-template': 'error',
         'udemy/no-hardcoded-cdns': [
             'error',
             [

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "12.0.8",
+  "version": "12.0.9",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "eslint-config-udemy-babel-addons": "^6.0.0",
-    "eslint-config-udemy-basics": "^8.0.3",
+    "eslint-config-udemy-basics": "^8.0.4",
     "eslint-config-udemy-jasmine-addons": "^8.0.1",
     "eslint-config-udemy-react-addons": "^10.0.2",
     "eslint-import-resolver-webpack": "^0.10.1",

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
- <a name="9.0.1"></a>
+       <a name="9.0.2"></a>
+## [9.0.2](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@9.0.1...eslint-plugin-udemy@9.0.2) (2019-07-29)
+
+
+
+
+**Note:** Version bump only for package eslint-plugin-udemy
+
+       <a name="9.0.1"></a>
 ## [9.0.1](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@9.0.0...eslint-plugin-udemy@9.0.1) (2019-01-28)
 
 
@@ -11,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package eslint-plugin-udemy
 
- <a name="9.0.0"></a>
+<a name="9.0.0"></a>
 # [9.0.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@8.0.0...eslint-plugin-udemy@9.0.0) (2019-01-28)
 
 

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {

--- a/packages/eslint-plugin-udemy/rules/no-gettext-template/README.md
+++ b/packages/eslint-plugin-udemy/rules/no-gettext-template/README.md
@@ -1,0 +1,19 @@
+# No template string formatting inside gettext()
+
+`udemy/no-gettext-template` checks for template string interpolation inside gettext calls. If templates are used inside gettext, whitespace gets pushed to TMS, causing potential issues on translation and unnecessary "new" strings on indentation changes.
+
+## Rule details
+
+The following would error:
+
+```js
+gettext(`some text
+         some more text`);
+```
+
+The following would not error:
+
+```js
+gettext('some text ' +
+        'some more text');
+```

--- a/packages/eslint-plugin-udemy/rules/no-gettext-template/index.js
+++ b/packages/eslint-plugin-udemy/rules/no-gettext-template/index.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * Switches quoting of javascript string from ` to ' escaping and unescaping as necessary.
+ *
+ * Does not convert curly variables - no-template-curly-in-string will alert you about those.
+ *
+ * Adapted from https://github.com/eslint/eslint/blob/master/lib/rules/quotes.js
+ */
+const convert = function(str) {
+    return (
+        // eslint-disable-next-line prefer-template
+        "'" +
+        str.slice(1, -1).replace(/\\(`)|'|(\s*\n\s*)/gu, (match, escaped, newline) => {
+            if (escaped === '`') {
+                return escaped; // unescape backticks
+            }
+            if (match === "'") {
+                return "\\'"; // escape single quotes
+            }
+            if (newline) {
+                return " ' +\n '"; // convert newlines(+whitespace) to string concatenation
+            }
+            return match;
+        }) +
+        "'"
+    );
+};
+
+module.exports.rules = {
+    'no-gettext-template': {
+        meta: {
+            type: 'problem',
+            schema: [],
+            fixable: 'code',
+        },
+
+        create(context) {
+            const sourceCode = context.getSourceCode();
+
+            return {
+                TemplateLiteral(node) {
+                    if (
+                        node.parent.type === 'CallExpression' &&
+                        node.parent.callee.name === 'gettext'
+                    ) {
+                        context.report({
+                            node,
+                            message: 'No template strings inside gettext.',
+                            fix(fixer) {
+                                return fixer.replaceText(node, convert(sourceCode.getText(node)));
+                            },
+                        });
+                    }
+                },
+            };
+        },
+    },
+};

--- a/packages/eslint-plugin-udemy/rules/no-gettext-template/tests.js
+++ b/packages/eslint-plugin-udemy/rules/no-gettext-template/tests.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+
+const rule = require('./index').rules['no-gettext-template'];
+
+RuleTester.setDefaultConfig({
+    parser: 'babel-eslint',
+});
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-gettext-template', rule, {
+    valid: [
+        {
+            code: `gettext('some text ' +
+                           'some more text')`,
+            options: [],
+        },
+        {
+            code: "gettext('simple line')",
+            options: [],
+        },
+    ],
+
+    invalid: [
+        {
+            code: 'gettext(`backticks for whatever reason.`)',
+            errors: [
+                {
+                    message: 'No template strings inside gettext.',
+                },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
@udemy/team-f moving the new rule from https://github.com/udemy/website-django/pull/35799 into js-tooling.

Would you be so kind to do the publishing please - the django PR is basically ready to merge, I can do so as soon as new version is available. Thanks!