### PR TITLE
TF-3869 Enable ESLint lines-between-class-members

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.13](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.9...babel-polyfill-udemy-website@9.0.13) (2019-08-14)
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+
+
+
+
 ## [9.0.12](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.9...babel-polyfill-udemy-website@9.0.12) (2019-08-13)
 
 **Note:** Version bump only for package babel-polyfill-udemy-website

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "9.0.12",
+  "version": "9.0.13",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^8.0.6",
-    "eslint-config-udemy-website": "^12.0.11",
+    "eslint-config-udemy-basics": "^9.0.0",
+    "eslint-config-udemy-website": "^12.0.12",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.0.10](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.6...babel-preset-udemy-website@11.0.10) (2019-08-14)
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+
+
+
+
 ## [11.0.9](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.6...babel-preset-udemy-website@11.0.9) (2019-08-13)
 
 **Note:** Version bump only for package babel-preset-udemy-website

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "11.0.9",
+  "version": "11.0.10",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^8.0.6",
-    "eslint-config-udemy-website": "^12.0.11",
+    "eslint-config-udemy-basics": "^9.0.0",
+    "eslint-config-udemy-website": "^12.0.12",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/eslint-config-tester/CHANGELOG.md
+++ b/packages/eslint-config-tester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-tester@3.0.0...eslint-config-tester@3.0.3) (2019-08-14)
+
+**Note:** Version bump only for package eslint-config-tester
+
+
+
+
+
 ## [3.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-tester@3.0.0...eslint-config-tester@3.0.2) (2019-08-13)
 
 **Note:** Version bump only for package eslint-config-tester

--- a/packages/eslint-config-tester/package.json
+++ b/packages/eslint-config-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tester",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "ESLint configuration tester",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-babel-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-babel-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-babel-addons@6.0.0...eslint-config-udemy-babel-addons@6.0.3) (2019-08-14)
+
+**Note:** Version bump only for package eslint-config-udemy-babel-addons
+
+
+
+
+
 ## [6.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-babel-addons@6.0.0...eslint-config-udemy-babel-addons@6.0.2) (2019-08-13)
 
 **Note:** Version bump only for package eslint-config-udemy-babel-addons

--- a/packages/eslint-config-udemy-babel-addons/package.json
+++ b/packages/eslint-config-udemy-babel-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-babel-addons",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Udemy's Babel related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -27,6 +27,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.2"
+    "eslint-config-tester": "^3.0.3"
   }
 }

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [9.0.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@8.0.3...eslint-config-udemy-basics@9.0.0) (2019-08-14)
+
+
+### Features
+
+* Enable ESLint lines-between-class-members ([9983e66](https://github.com/udemy/js-tooling/commit/9983e66))
+
+
+### BREAKING CHANGES
+
+* https://eslint.org/docs/rules/lines-between-class-members is enabled. See https://github.com/udemy/website-django/pull/35570 for discussion.
+
+
+
+
+
 ## [8.0.6](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@8.0.3...eslint-config-udemy-basics@8.0.6) (2019-08-13)
 
 **Note:** Version bump only for package eslint-config-udemy-basics

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "8.0.6",
+  "version": "9.0.0",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -20,7 +20,7 @@
     "eslint-plugin-import-order-alphabetical": "^0.0.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-udemy": "^9.0.4"
+    "eslint-plugin-udemy": "^9.0.5"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
@@ -32,6 +32,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.2"
+    "eslint-config-tester": "^3.0.3"
   }
 }

--- a/packages/eslint-config-udemy-basics/parts/stylistic-issues.js
+++ b/packages/eslint-config-udemy-basics/parts/stylistic-issues.js
@@ -17,6 +17,8 @@ module.exports = {
         ],
         // enforce consistent linebreak style
         'linebreak-style': ['error', 'unix'],
+        // enforce consistent number of newlines between class members
+        'lines-between-class-members': ['error', 'always', {exceptAfterSingleLine: true}],
         // specify the maximum number of statement allowed in a function
         'max-statements': ['error', 40],
         // require a capital letter for constructors

--- a/packages/eslint-config-udemy-jasmine-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-jasmine-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-jasmine-addons@8.0.1...eslint-config-udemy-jasmine-addons@8.0.4) (2019-08-14)
+
+**Note:** Version bump only for package eslint-config-udemy-jasmine-addons
+
+
+
+
+
 ## [8.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-jasmine-addons@8.0.1...eslint-config-udemy-jasmine-addons@8.0.3) (2019-08-13)
 
 **Note:** Version bump only for package eslint-config-udemy-jasmine-addons

--- a/packages/eslint-config-udemy-jasmine-addons/package.json
+++ b/packages/eslint-config-udemy-jasmine-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-jasmine-addons",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "Udemy's Jasmine related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -25,6 +25,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.2"
+    "eslint-config-tester": "^3.0.3"
   }
 }

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [10.0.5](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@10.0.2...eslint-config-udemy-react-addons@10.0.5) (2019-08-14)
+
+**Note:** Version bump only for package eslint-config-udemy-react-addons
+
+
+
+
+
 ## [10.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@10.0.2...eslint-config-udemy-react-addons@10.0.4) (2019-08-13)
 
 **Note:** Version bump only for package eslint-config-udemy-react-addons

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -27,6 +27,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.2"
+    "eslint-config-tester": "^3.0.3"
   }
 }

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [12.0.12](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.8...eslint-config-udemy-website@12.0.12) (2019-08-14)
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
+
+
+
+
 ## [12.0.11](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.8...eslint-config-udemy-website@12.0.11) (2019-08-13)
 
 **Note:** Version bump only for package eslint-config-udemy-website

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "12.0.11",
+  "version": "12.0.12",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -14,10 +14,10 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "dependencies": {
-    "eslint-config-udemy-babel-addons": "^6.0.2",
-    "eslint-config-udemy-basics": "^8.0.6",
-    "eslint-config-udemy-jasmine-addons": "^8.0.3",
-    "eslint-config-udemy-react-addons": "^10.0.4",
+    "eslint-config-udemy-babel-addons": "^6.0.3",
+    "eslint-config-udemy-basics": "^9.0.0",
+    "eslint-config-udemy-jasmine-addons": "^8.0.4",
+    "eslint-config-udemy-react-addons": "^10.0.5",
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.14.0",
@@ -33,6 +33,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.2"
+    "eslint-config-tester": "^3.0.3"
   }
 }

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.5](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@9.0.1...eslint-plugin-udemy@9.0.5) (2019-08-14)
+
+**Note:** Version bump only for package eslint-plugin-udemy
+
+
+
+
+
 ## [9.0.4](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@9.0.1...eslint-plugin-udemy@9.0.4) (2019-08-13)
 
 **Note:** Version bump only for package eslint-plugin-udemy

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {
@@ -16,7 +16,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-tester": "^3.0.2"
+    "eslint-config-tester": "^3.0.3"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/prettier-config-udemy-website/CHANGELOG.md
+++ b/packages/prettier-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.3 (2019-08-14)
+
+**Note:** Version bump only for package prettier-config-udemy-website
+
+
+
+
+
 ## [1.0.2](https://github.com/udemy/js-tooling/compare/prettier-config-udemy-website@1.0.1...prettier-config-udemy-website@1.0.2) (2019-08-13)
 
 **Note:** Version bump only for package prettier-config-udemy-website

--- a/packages/prettier-config-udemy-website/package.json
+++ b/packages/prettier-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-udemy-website",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Udemy's Prettier configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@cwick @udemy/team-f 

##### *What:*
Enable ESLint lines-between-class-members. See https://github.com/udemy/website-django/pull/35570 for discussion.

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3869

##### *What did you test:*
For website-django `static` and `e2e`:

```
yarn add --dev file:/Users/kevin.zhang/Desktop/website/js-tooling/packages/eslint-config-udemy-basics

yarn run lint

Fix linting errors for lines-between-class-members
```

##### *What dashboards will you be monitoring:*
None
