### PR TITLE
TF-3881 Fix GitHub security alerts for mixin-deep and set-value

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.15](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.14...babel-polyfill-udemy-website@9.0.15) (2019-09-04)
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+
+
+
+
 ## [9.0.14](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.13...babel-polyfill-udemy-website@9.0.14) (2019-08-27)
 
 **Note:** Version bump only for package babel-polyfill-udemy-website

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "9.0.14",
+  "version": "9.0.15",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^9.0.1",
-    "eslint-config-udemy-website": "^12.0.13",
+    "eslint-config-udemy-basics": "^9.0.2",
+    "eslint-config-udemy-website": "^12.0.14",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.0.12](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.11...babel-preset-udemy-website@11.0.12) (2019-09-04)
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+
+
+
+
 ## [11.0.11](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.10...babel-preset-udemy-website@11.0.11) (2019-08-27)
 
 **Note:** Version bump only for package babel-preset-udemy-website

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "11.0.11",
+  "version": "11.0.12",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^9.0.1",
-    "eslint-config-udemy-website": "^12.0.13",
+    "eslint-config-udemy-basics": "^9.0.2",
+    "eslint-config-udemy-website": "^12.0.14",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/eslint-config-tester/CHANGELOG.md
+++ b/packages/eslint-config-tester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.5](https://github.com/udemy/js-tooling/compare/eslint-config-tester@3.0.4...eslint-config-tester@3.0.5) (2019-09-04)
+
+**Note:** Version bump only for package eslint-config-tester
+
+
+
+
+
 ## [3.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-tester@3.0.3...eslint-config-tester@3.0.4) (2019-08-27)
 
 **Note:** Version bump only for package eslint-config-tester

--- a/packages/eslint-config-tester/package.json
+++ b/packages/eslint-config-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tester",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "ESLint configuration tester",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-babel-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-babel-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.5](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-babel-addons@6.0.4...eslint-config-udemy-babel-addons@6.0.5) (2019-09-04)
+
+**Note:** Version bump only for package eslint-config-udemy-babel-addons
+
+
+
+
+
 ## [6.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-babel-addons@6.0.3...eslint-config-udemy-babel-addons@6.0.4) (2019-08-27)
 
 **Note:** Version bump only for package eslint-config-udemy-babel-addons

--- a/packages/eslint-config-udemy-babel-addons/package.json
+++ b/packages/eslint-config-udemy-babel-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-babel-addons",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Udemy's Babel related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -27,6 +27,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.4"
+    "eslint-config-tester": "^3.0.5"
   }
 }

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.2](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@9.0.1...eslint-config-udemy-basics@9.0.2) (2019-09-04)
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
+
+
+
+
 ## [9.0.1](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@9.0.0...eslint-config-udemy-basics@9.0.1) (2019-08-27)
 
 **Note:** Version bump only for package eslint-config-udemy-basics

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -20,7 +20,7 @@
     "eslint-plugin-import-order-alphabetical": "^0.0.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-udemy": "^9.0.6"
+    "eslint-plugin-udemy": "^9.0.7"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
@@ -32,6 +32,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.4"
+    "eslint-config-tester": "^3.0.5"
   }
 }

--- a/packages/eslint-config-udemy-jasmine-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-jasmine-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.0.6](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-jasmine-addons@8.0.5...eslint-config-udemy-jasmine-addons@8.0.6) (2019-09-04)
+
+**Note:** Version bump only for package eslint-config-udemy-jasmine-addons
+
+
+
+
+
 ## [8.0.5](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-jasmine-addons@8.0.4...eslint-config-udemy-jasmine-addons@8.0.5) (2019-08-27)
 
 **Note:** Version bump only for package eslint-config-udemy-jasmine-addons

--- a/packages/eslint-config-udemy-jasmine-addons/package.json
+++ b/packages/eslint-config-udemy-jasmine-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-jasmine-addons",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "description": "Udemy's Jasmine related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -25,6 +25,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.4"
+    "eslint-config-tester": "^3.0.5"
   }
 }

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [10.0.7](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@10.0.6...eslint-config-udemy-react-addons@10.0.7) (2019-09-04)
+
+**Note:** Version bump only for package eslint-config-udemy-react-addons
+
+
+
+
+
 ## [10.0.6](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@10.0.5...eslint-config-udemy-react-addons@10.0.6) (2019-08-27)
 
 **Note:** Version bump only for package eslint-config-udemy-react-addons

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -27,6 +27,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.4"
+    "eslint-config-tester": "^3.0.5"
   }
 }

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [12.0.14](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.13...eslint-config-udemy-website@12.0.14) (2019-09-04)
+
+**Note:** Version bump only for package eslint-config-udemy-website
+
+
+
+
+
 ## [12.0.13](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.12...eslint-config-udemy-website@12.0.13) (2019-08-27)
 
 **Note:** Version bump only for package eslint-config-udemy-website

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "12.0.13",
+  "version": "12.0.14",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -14,10 +14,10 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "dependencies": {
-    "eslint-config-udemy-babel-addons": "^6.0.4",
-    "eslint-config-udemy-basics": "^9.0.1",
-    "eslint-config-udemy-jasmine-addons": "^8.0.5",
-    "eslint-config-udemy-react-addons": "^10.0.6",
+    "eslint-config-udemy-babel-addons": "^6.0.5",
+    "eslint-config-udemy-basics": "^9.0.2",
+    "eslint-config-udemy-jasmine-addons": "^8.0.6",
+    "eslint-config-udemy-react-addons": "^10.0.7",
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.14.0",
@@ -33,6 +33,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.4"
+    "eslint-config-tester": "^3.0.5"
   }
 }

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.7](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@9.0.6...eslint-plugin-udemy@9.0.7) (2019-09-04)
+
+**Note:** Version bump only for package eslint-plugin-udemy
+
+
+
+
+
 ## [9.0.6](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@9.0.5...eslint-plugin-udemy@9.0.6) (2019-08-27)
 
 **Note:** Version bump only for package eslint-plugin-udemy

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "9.0.6",
+  "version": "9.0.7",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {
@@ -16,7 +16,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-tester": "^3.0.4"
+    "eslint-config-tester": "^3.0.5"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/prettier-config-udemy-website/CHANGELOG.md
+++ b/packages/prettier-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.5](https://github.com/udemy/js-tooling/compare/prettier-config-udemy-website@1.0.4...prettier-config-udemy-website@1.0.5) (2019-09-04)
+
+**Note:** Version bump only for package prettier-config-udemy-website
+
+
+
+
+
 ## [1.0.4](https://github.com/udemy/js-tooling/compare/prettier-config-udemy-website@1.0.3...prettier-config-udemy-website@1.0.4) (2019-08-27)
 
 **Note:** Version bump only for package prettier-config-udemy-website

--- a/packages/prettier-config-udemy-website/package.json
+++ b/packages/prettier-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-udemy-website",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Udemy's Prettier configuration",
   "main": "index.js",
   "author": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,7 +3949,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
@@ -4585,8 +4585,8 @@ mississippi@^3.0.0:
     through2 "^2.0.0"
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -5908,18 +5908,9 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
-set-value@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.1"
-    to-object-path "^0.3.0"
-
-set-value@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+set-value@^2.0.0, set-value@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"
@@ -6473,13 +6464,13 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
 
 union-value@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
   dependencies:
     arr-union "^3.1.0"
     get-value "^2.0.6"
     is-extendable "^0.1.1"
-    set-value "^0.4.3"
+    set-value "^2.0.1"
 
 unique-filename@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
##### *To:*
@cwick @udemy/team-f 

##### *What:*
Fix GitHub security alerts for mixin-deep and set-value. We got the exact same alerts for website-django, and I am resolving them the exact same way: see https://github.com/udemy/website-django/pull/36743.

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3881

##### *What did you test:*
Nothing as these packages are not user-facing- see https://github.com/udemy/website-django/pull/36743 for explanation.

##### *What dashboards will you be monitoring:*
None
