### PR TITLE
TF-3912 Add udlite-import-blacklist

### DIFF
--- a/packages/babel-polyfill-udemy-website/CHANGELOG.md
+++ b/packages/babel-polyfill-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.17](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.16...babel-polyfill-udemy-website@9.0.17) (2019-10-16)
+
+**Note:** Version bump only for package babel-polyfill-udemy-website
+
+
+
+
+
 ## [9.0.16](https://github.com/udemy/js-tooling/compare/babel-polyfill-udemy-website@9.0.15...babel-polyfill-udemy-website@9.0.16) (2019-09-26)
 
 **Note:** Version bump only for package babel-polyfill-udemy-website

--- a/packages/babel-polyfill-udemy-website/package.json
+++ b/packages/babel-polyfill-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-polyfill-udemy-website",
-  "version": "9.0.16",
+  "version": "9.0.17",
   "description": "Udemy Website's Babel polyfill",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^9.0.3",
-    "eslint-config-udemy-website": "^12.0.15",
+    "eslint-config-udemy-basics": "^9.0.4",
+    "eslint-config-udemy-website": "^12.1.0",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/babel-preset-udemy-website/CHANGELOG.md
+++ b/packages/babel-preset-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [11.0.14](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.13...babel-preset-udemy-website@11.0.14) (2019-10-16)
+
+**Note:** Version bump only for package babel-preset-udemy-website
+
+
+
+
+
 ## [11.0.13](https://github.com/udemy/js-tooling/compare/babel-preset-udemy-website@11.0.12...babel-preset-udemy-website@11.0.13) (2019-09-26)
 
 **Note:** Version bump only for package babel-preset-udemy-website

--- a/packages/babel-preset-udemy-website/package.json
+++ b/packages/babel-preset-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-udemy-website",
-  "version": "11.0.13",
+  "version": "11.0.14",
   "description": "Udemy Website's Babel preset",
   "main": "index.js",
   "author": {
@@ -20,8 +20,8 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-udemy-basics": "^9.0.3",
-    "eslint-config-udemy-website": "^12.0.15",
+    "eslint-config-udemy-basics": "^9.0.4",
+    "eslint-config-udemy-website": "^12.1.0",
     "prettier": "^1.16.1"
   },
   "dependencies": {

--- a/packages/eslint-config-tester/CHANGELOG.md
+++ b/packages/eslint-config-tester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.7](https://github.com/udemy/js-tooling/compare/eslint-config-tester@3.0.6...eslint-config-tester@3.0.7) (2019-10-16)
+
+**Note:** Version bump only for package eslint-config-tester
+
+
+
+
+
 ## [3.0.6](https://github.com/udemy/js-tooling/compare/eslint-config-tester@3.0.5...eslint-config-tester@3.0.6) (2019-09-26)
 
 **Note:** Version bump only for package eslint-config-tester

--- a/packages/eslint-config-tester/package.json
+++ b/packages/eslint-config-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tester",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "ESLint configuration tester",
   "main": "index.js",
   "author": {

--- a/packages/eslint-config-udemy-babel-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-babel-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.7](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-babel-addons@6.0.6...eslint-config-udemy-babel-addons@6.0.7) (2019-10-16)
+
+**Note:** Version bump only for package eslint-config-udemy-babel-addons
+
+
+
+
+
 ## [6.0.6](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-babel-addons@6.0.5...eslint-config-udemy-babel-addons@6.0.6) (2019-09-26)
 
 **Note:** Version bump only for package eslint-config-udemy-babel-addons

--- a/packages/eslint-config-udemy-babel-addons/package.json
+++ b/packages/eslint-config-udemy-babel-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-babel-addons",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Udemy's Babel related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -27,6 +27,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.6"
+    "eslint-config-tester": "^3.0.7"
   }
 }

--- a/packages/eslint-config-udemy-basics/CHANGELOG.md
+++ b/packages/eslint-config-udemy-basics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.4](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@9.0.3...eslint-config-udemy-basics@9.0.4) (2019-10-16)
+
+**Note:** Version bump only for package eslint-config-udemy-basics
+
+
+
+
+
 ## [9.0.3](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-basics@9.0.2...eslint-config-udemy-basics@9.0.3) (2019-09-26)
 
 **Note:** Version bump only for package eslint-config-udemy-basics

--- a/packages/eslint-config-udemy-basics/package.json
+++ b/packages/eslint-config-udemy-basics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-basics",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Udemy's Base ESLint configuration",
   "main": "index.js",
   "author": {
@@ -20,7 +20,7 @@
     "eslint-plugin-import-order-alphabetical": "^0.0.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-udemy": "^9.0.8"
+    "eslint-plugin-udemy": "^9.1.0"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
@@ -32,6 +32,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.6"
+    "eslint-config-tester": "^3.0.7"
   }
 }

--- a/packages/eslint-config-udemy-jasmine-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-jasmine-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.0.8](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-jasmine-addons@8.0.7...eslint-config-udemy-jasmine-addons@8.0.8) (2019-10-16)
+
+**Note:** Version bump only for package eslint-config-udemy-jasmine-addons
+
+
+
+
+
 ## [8.0.7](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-jasmine-addons@8.0.6...eslint-config-udemy-jasmine-addons@8.0.7) (2019-09-26)
 
 **Note:** Version bump only for package eslint-config-udemy-jasmine-addons

--- a/packages/eslint-config-udemy-jasmine-addons/package.json
+++ b/packages/eslint-config-udemy-jasmine-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-jasmine-addons",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "description": "Udemy's Jasmine related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -25,6 +25,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.6"
+    "eslint-config-tester": "^3.0.7"
   }
 }

--- a/packages/eslint-config-udemy-react-addons/CHANGELOG.md
+++ b/packages/eslint-config-udemy-react-addons/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [10.0.9](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@10.0.8...eslint-config-udemy-react-addons@10.0.9) (2019-10-16)
+
+**Note:** Version bump only for package eslint-config-udemy-react-addons
+
+
+
+
+
 ## [10.0.8](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-react-addons@10.0.7...eslint-config-udemy-react-addons@10.0.8) (2019-09-26)
 
 **Note:** Version bump only for package eslint-config-udemy-react-addons

--- a/packages/eslint-config-udemy-react-addons/package.json
+++ b/packages/eslint-config-udemy-react-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-react-addons",
-  "version": "10.0.8",
+  "version": "10.0.9",
   "description": "Udemy's React related ESLint configuration",
   "main": "index.js",
   "author": {
@@ -27,6 +27,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.6"
+    "eslint-config-tester": "^3.0.7"
   }
 }

--- a/packages/eslint-config-udemy-website/CHANGELOG.md
+++ b/packages/eslint-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [12.1.0](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.15...eslint-config-udemy-website@12.1.0) (2019-10-16)
+
+
+### Features
+
+* add udlite-import-blacklist ([b832fc0](https://github.com/udemy/js-tooling/commit/b832fc0))
+
+
+
+
+
 ## [12.0.15](https://github.com/udemy/js-tooling/compare/eslint-config-udemy-website@12.0.14...eslint-config-udemy-website@12.0.15) (2019-09-26)
 
 **Note:** Version bump only for package eslint-config-udemy-website

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -108,7 +108,7 @@ module.exports = {
                         "Please `import MemoizedBrowserRouter from 'base-components/memoized-browser-router.react-component';`, " +
                         "not `import { BrowserRouter, HashRouter, Router } from 'react-router-dom';`.",
                     exceptions: [
-                        'base-components/memoized-browser-router.react-component(?:\\.spec)?\\.js$',
+                        'base-components/udlite/router/memoized-browser-router.react-component(?:\\.spec)?\\.js$',
                     ],
                 },
                 {
@@ -118,7 +118,9 @@ module.exports = {
                     message:
                         "Please `import Link from 'base-components/link.react-component';`, " +
                         "not `import { Link } from 'react-router-dom';`.",
-                    exceptions: ['base-components/link.react-component(?:\\.spec)?\\.js$'],
+                    exceptions: [
+                        'base-components/udlite/router/link.react-component(?:\\.spec)?\\.js$',
+                    ],
                 },
                 {
                     // Tapen only lib
@@ -137,6 +139,80 @@ module.exports = {
                     source: '^vis-react(?:\\.js)?$',
                     message: 'vis-react is only allowed in tapen',
                     exceptions: ['tapen/.*?\\.js$'],
+                },
+            ],
+        ],
+        'udemy/udlite-import-blacklist': [
+            'error',
+            [
+                {
+                    source: 'base-components/(?!udlite/)',
+                    message:
+                        'UDLite files may not import UDHeavy base-components. ' +
+                        'Replace the following with a base-components/udlite/ component:',
+                },
+                {
+                    source: '(react-bootstrap|react-overlays|react-router-bootstrap)',
+                    message:
+                        'UDLite files may not import React-Bootstrap libs. ' +
+                        'Replace the following with a base-components/udlite/ component:',
+                },
+                {
+                    source: '(react-popper|popper.js)',
+                    message:
+                        'UDLite files may not import Popper. ' +
+                        'Replace the following with a base-components/udlite/ component:',
+                },
+                {
+                    source: '(react-slick|slick-carousel)',
+                    message:
+                        'UDLite files may not import Slick carousel. ' +
+                        'Replace the following with ' +
+                        'base-components/udlite/carousel/carousel.react-component:',
+                },
+                {
+                    source: 'react-waypoint',
+                    message:
+                        'UDLite files may not import React Waypoint. ' +
+                        'Replace the following with ' +
+                        '@researchgate/react-intersection-observer:',
+                },
+                {
+                    source: 'velocity',
+                    message:
+                        'UDLite files may not import Velociy. ' +
+                        'Only CSS animations are allowed:',
+                },
+                {
+                    source: 'utils/ud-utils$',
+                    message:
+                        'UDLite files may not import utils/ud-utils. ' +
+                        'Replace udUtils.Feedback with ui-feedback/udlite. ' +
+                        'The rest is split up into smaller utils/ files:',
+                },
+                {
+                    source: '(lodash|lodash-es)/(?!noop)',
+                    message:
+                        'UDLite files may not use Lodash. ' +
+                        'Replace the following with ES6 or one of our own utils/ functions:',
+                },
+                {
+                    source: '(jquery|jQuery)',
+                    message: 'UDLite files may not use jQuery:',
+                },
+                {
+                    source: 'jsuri',
+                    message: 'UDLite files may not use jsuri. Replace with URLSearchParams:',
+                },
+                {
+                    source: '(^moment$|ud-moment)',
+                    message:
+                        'UDLite files may not use moment. ' +
+                        'Ask #dev-team-web-frontend about your use-case:',
+                },
+                {
+                    source: '(^numeral$|ud-numeral)',
+                    message: 'UDLite files may not use numeral. Replace with udlite-numeral:',
                 },
             ],
         ],

--- a/packages/eslint-config-udemy-website/package.json
+++ b/packages/eslint-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udemy-website",
-  "version": "12.0.15",
+  "version": "12.1.0",
   "description": "Udemy Website's ESLint configuration",
   "main": "index.js",
   "author": {
@@ -14,10 +14,10 @@
     "url": "https://github.com/udemy/js-tooling.git"
   },
   "dependencies": {
-    "eslint-config-udemy-babel-addons": "^6.0.6",
-    "eslint-config-udemy-basics": "^9.0.3",
-    "eslint-config-udemy-jasmine-addons": "^8.0.7",
-    "eslint-config-udemy-react-addons": "^10.0.8",
+    "eslint-config-udemy-babel-addons": "^6.0.7",
+    "eslint-config-udemy-basics": "^9.0.4",
+    "eslint-config-udemy-jasmine-addons": "^8.0.8",
+    "eslint-config-udemy-react-addons": "^10.0.9",
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.14.0",
@@ -33,6 +33,6 @@
     "yarn": "^1.9.4"
   },
   "devDependencies": {
-    "eslint-config-tester": "^3.0.6"
+    "eslint-config-tester": "^3.0.7"
   }
 }

--- a/packages/eslint-plugin-udemy/CHANGELOG.md
+++ b/packages/eslint-plugin-udemy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [9.1.0](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@9.0.8...eslint-plugin-udemy@9.1.0) (2019-10-16)
+
+
+### Features
+
+* add udlite-import-blacklist ([b832fc0](https://github.com/udemy/js-tooling/commit/b832fc0))
+
+
+
+
+
 ## [9.0.8](https://github.com/udemy/js-tooling/compare/eslint-plugin-udemy@9.0.7...eslint-plugin-udemy@9.0.8) (2019-09-26)
 
 **Note:** Version bump only for package eslint-plugin-udemy

--- a/packages/eslint-plugin-udemy/package.json
+++ b/packages/eslint-plugin-udemy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-udemy",
-  "version": "9.0.8",
+  "version": "9.1.0",
   "description": "Udemy's ESLint plugin",
   "main": "index.js",
   "author": {
@@ -16,7 +16,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.9.0",
-    "eslint-config-tester": "^3.0.6"
+    "eslint-config-tester": "^3.0.7"
   },
   "engines": {
     "node": ">=8.12.0",

--- a/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/README.md
+++ b/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/README.md
@@ -1,0 +1,31 @@
+# UDLite Import Blacklist
+
+`udemy/udlite-import-blacklist` blacklists certain imports in UDLite files, i.e. files in a udlite/ directory. In general, UDLite blacklists:
+
+- UDHeavy base-components, in favor of UDLite base-components.
+- most third-party libs that UDHeavy uses, in favor of smaller alternatives (in terms of JS size).
+
+Test files (`.spec.js` files, `spec-helpers.js`) are exempt from the rule.
+
+## Rule details
+
+The blacklist is configured by a list of regexes.
+
+Assuming the following configuration:
+
+```js
+'udemy/udlite-import-blacklist': ['error', [
+    {
+        source: 'heavyweight-lib',
+        message: 'UDLite files may not import Heavyweight lib',
+    },
+]]
+```
+
+The following imports would error, but only for non-test files in a udlite/ directory:
+
+```js 
+import 'heavyweight-lib';
+import {foo, bar} from 'heavyweight-lib.js';
+import {foo} from 'heavyweight-lib/foo';
+```

--- a/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/index.js
+++ b/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+module.exports.rules = {
+    'udlite-import-blacklist': {
+        meta: {
+            schema: [
+                {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            source: {
+                                type: 'string',
+                            },
+                            message: {
+                                type: 'string',
+                            },
+                        },
+                        required: ['source', 'message'],
+                    },
+                },
+            ],
+        },
+        create: function create(context) {
+            const blacklist = context.options[0] || [];
+            const filename = context.getFilename();
+
+            if (!filename.includes('/udlite/')) {
+                return {};
+            }
+
+            if (filename.endsWith('.spec.js') || filename.endsWith('/spec-helpers.js')) {
+                return {};
+            }
+
+            return {
+                ImportDeclaration: function ImportDeclaration(node) {
+                    blacklist.forEach(rule => {
+                        const sourceValue = node.source.value || '';
+                        const sourceMatches = sourceValue.match(new RegExp(rule.source));
+                        if (sourceMatches) {
+                            context.report({
+                                node,
+                                message: `${rule.message}\n${sourceValue}\n`,
+                            });
+                        }
+                    });
+                },
+            };
+        },
+    },
+};

--- a/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/tests.js
+++ b/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/tests.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const path = require('path');
+
+const rule = require('./index').rules['udlite-import-blacklist'];
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2015,
+        sourceType: 'module',
+    },
+});
+
+const options = [
+    [
+        {
+            source: 'heavyweight-lib',
+            message: 'UDLite files may not import Heavyweight lib:',
+        },
+    ],
+];
+
+ruleTester.run('udlite-import-blacklist', rule, {
+    valid: [
+        {
+            code: "import 'lightweight-lib';",
+            filename: path.join(__dirname, 'js/udlite/example.js'),
+            options,
+        },
+        {
+            code: "import 'heavyweight-lib';",
+            filename: path.join(__dirname, 'js/udheavy/example.js'),
+            options,
+        },
+        {
+            code: "import 'heavyweight-lib';",
+            filename: path.join(__dirname, 'js/udlite/example.spec.js'),
+            options,
+        },
+    ],
+    invalid: [
+        {
+            code: "import 'heavyweight-lib';",
+            errors: [
+                {
+                    message: 'UDLite files may not import Heavyweight lib:\nheavyweight-lib\n',
+                },
+            ],
+            filename: path.join(__dirname, 'js/udlite/example.js'),
+            options,
+        },
+    ],
+});

--- a/packages/prettier-config-udemy-website/CHANGELOG.md
+++ b/packages/prettier-config-udemy-website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.7](https://github.com/udemy/js-tooling/compare/prettier-config-udemy-website@1.0.6...prettier-config-udemy-website@1.0.7) (2019-10-16)
+
+**Note:** Version bump only for package prettier-config-udemy-website
+
+
+
+
+
 ## [1.0.6](https://github.com/udemy/js-tooling/compare/prettier-config-udemy-website@1.0.5...prettier-config-udemy-website@1.0.6) (2019-09-26)
 
 **Note:** Version bump only for package prettier-config-udemy-website

--- a/packages/prettier-config-udemy-website/package.json
+++ b/packages/prettier-config-udemy-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-udemy-website",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Udemy's Prettier configuration",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
##### *To:*
@cwick @udemy/web-frontend 

##### *What:*
Add udlite-import-blacklist. Prevents files in a udlite/ directory from importing UDHeavy base-components. Also, I skimmed through our package.json and blacklisted a handful of third-party libs that we don't want in UDLite, e.g. jquery, lodash, etc.

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-3912

##### *What did you test:*
Ran the rule locally in website-django.

##### *What dashboards will you be monitoring:*
None
