### PR TITLE
Upgrade kind-of to resolve security alert

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4215,8 +4215,8 @@ kind-of@^5.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
 
 kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
 
 lcid@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
##### *To:*
@udemy/web-frontend 

##### *What:*
Upgrade kind-of to resolve security alert.

https://github.com/udemy/js-tooling/network/alerts

```
kind-of@6.0.3
```

<details><summary>kind-of</summary>
Remediation
Upgrade kind-of to version 6.0.3 or later. For example:

```
kind-of@^6.0.3:
  version "6.0.3"
```

Details
[CVE-2019-20149](https://github.com/advisories/GHSA-6c8f-qphg-qjgp)
moderate severity
Vulnerable versions: = 6.0.2
Patched version: 6.0.3
ctorName in index.js in kind-of v6.0.2 allows external user input to overwrite certain internal attributes via a conflicting name, as demonstrated by 'constructor': {'name':'Symbol'}. Hence, a crafted payload can overwrite this builtin attribute to manipulate the type detection result.
</details>

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-4060

##### *What did you test:*
I hope CI passes.

##### *What dashboards will you be monitoring:*
None
