### PR TITLE
Upgrade mkdirp, minimist to resolve security alert

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4621,13 +4621,9 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-
-minimist@^1.1.3, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
 
 minipass@^2.2.1, minipass@^2.3.4, minipass@^2.3.5:
   version "2.3.5"
@@ -4677,10 +4673,10 @@ mkdirp-promise@^5.0.1:
     mkdirp "*"
 
 mkdirp@*, mkdirp@^0.5.0, mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.2.tgz#2e7138d794dfbd097d74c84c410c3edd9eec479f"
   dependencies:
-    minimist "0.0.8"
+    minimist "^1.2.5"
 
 modify-values@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
##### *To:*
@udemy/web-frontend 

##### *What:*
Upgrade mkdirp, minimist to resolve security alert.

https://github.com/udemy/js-tooling/network/alerts

```
mkdirp@0.5.2
minimist@1.2.5
```

<details><summary>minimist</summary>
Remediation
Upgrade minimist to version 1.2.3 or later. For example:

```
minimist@^1.2.3:
  version "1.2.3"
```

Details
[CVE-2020-7598](https://github.com/advisories/GHSA-vh95-rmgr-6w4m)
moderate severity
Vulnerable versions: >= 1.0.0, < 1.2.3
Patched version: 1.2.3
minimist before 1.2.2 could be tricked into adding or modifying properties of Object.prototype using a "constructor" or "proto" payload.
</details>

##### *JIRA:*
https://udemyjira.atlassian.net/browse/TF-4060

##### *What did you test:*
I hope CI passes.

##### *What dashboards will you be monitoring:*
None
