### PR TITLE
More accurate check for whether a file is UDLite

### DIFF
--- a/packages/eslint-plugin-udemy/helpers/is-udlite-file.js
+++ b/packages/eslint-plugin-udemy/helpers/is-udlite-file.js
@@ -24,16 +24,15 @@ function findUDLiteDirs(dir) {
     }
 
     const udliteDirs = [];
-    if (
-        fs.existsSync(path.join(dir, 'udlite-app.js')) &&
-        !fs.existsSync(path.join(dir, 'app.js'))
-    ) {
+    const children = fs.readdirSync(dir);
+    const childrenSet = new Set(children);
+    if (childrenSet.has('udlite-app.js') && !childrenSet.has('app.js')) {
         udliteDirs.push(dir);
-    } else if (fs.existsSync(path.join(dir, 'udlite.md'))) {
+    } else if (childrenSet.has('udlite.md')) {
         udliteDirs.push(dir);
     }
 
-    fs.readdirSync(dir).forEach(child => {
+    children.forEach(child => {
         const childPath = path.join(dir, child);
         if (fs.lstatSync(childPath).isDirectory()) {
             udliteDirs.push(...findUDLiteDirs(childPath));

--- a/packages/eslint-plugin-udemy/helpers/is-udlite-file.js
+++ b/packages/eslint-plugin-udemy/helpers/is-udlite-file.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+let cachedUDLiteDirs = null;
+
+exports.isUDLiteFile = filename => {
+    if (!filename.includes('/static/src/udemy/js/')) {
+        return false;
+    }
+
+    if (cachedUDLiteDirs === null) {
+        const jsDir = path.join(filename.split('/static/src/udemy/js/')[0], 'static/src/udemy/js');
+        cachedUDLiteDirs = findUDLiteDirs(jsDir);
+    }
+
+    return filename.includes('udlite') || cachedUDLiteDirs.some(dir => filename.startsWith(dir));
+};
+
+function findUDLiteDirs(dir) {
+    if (!fs.existsSync(dir)) {
+        return [];
+    }
+
+    const udliteDirs = [];
+    if (
+        fs.existsSync(path.join(dir, 'udlite-app.js')) &&
+        !fs.existsSync(path.join(dir, 'app.js'))
+    ) {
+        udliteDirs.push(dir);
+    } else if (fs.existsSync(path.join(dir, 'udlite.md'))) {
+        udliteDirs.push(dir);
+    }
+
+    fs.readdirSync(dir).forEach(child => {
+        const childPath = path.join(dir, child);
+        if (fs.lstatSync(childPath).isDirectory()) {
+            udliteDirs.push(...findUDLiteDirs(childPath));
+        }
+    });
+
+    return udliteDirs;
+}

--- a/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/index.js
+++ b/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {isUDLiteFile} = require('../../helpers/is-udlite-file.js');
+
 module.exports.rules = {
     'udlite-import-blacklist': {
         meta: {
@@ -25,7 +27,7 @@ module.exports.rules = {
             const blacklist = context.options[0] || [];
             const filename = context.getFilename();
 
-            if (!filename.includes('/udlite/')) {
+            if (!isUDLiteFile(filename)) {
                 return {};
             }
 

--- a/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/tests.js
+++ b/packages/eslint-plugin-udemy/rules/udlite-import-blacklist/tests.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const path = require('path');
 
 const rule = require('./index').rules['udlite-import-blacklist'];
 
@@ -25,17 +24,17 @@ ruleTester.run('udlite-import-blacklist', rule, {
     valid: [
         {
             code: "import 'lightweight-lib';",
-            filename: path.join(__dirname, 'js/udlite/example.js'),
+            filename: '/path/to/static/src/udemy/js/udlite/example.js',
             options,
         },
         {
             code: "import 'heavyweight-lib';",
-            filename: path.join(__dirname, 'js/udheavy/example.js'),
+            filename: '/path/to/static/src/udemy/js/udheavy/example.js',
             options,
         },
         {
             code: "import 'heavyweight-lib';",
-            filename: path.join(__dirname, 'js/udlite/example.spec.js'),
+            filename: '/path/to/static/src/udemy/js/udlite/example.spec.js',
             options,
         },
     ],
@@ -47,7 +46,7 @@ ruleTester.run('udlite-import-blacklist', rule, {
                     message: 'UDLite files may not import Heavyweight lib:\nheavyweight-lib\n',
                 },
             ],
-            filename: path.join(__dirname, 'js/udlite/example.js'),
+            filename: '/path/to/static/src/udemy/js/udlite/example.js',
             options,
         },
     ],


### PR DESCRIPTION
##### *To:*
@jillesme @udemy/web-frontend 

##### *What:*
More accurate check for whether a file is UDLite. I noticed that we have some "pure" UDLite apps that aren't inside a udlite/ directory, e.g. occupation/pages/occupation-explorer/udlite-app.js. These apps are bypassing our UDLite linting, namely the `udlite-import-blacklist` ESLint rule and a handful of lesshint rules defined in website-django.

This PR introduces an is-udlite-file.js helper function which determines whether a file is UDLite as follows:
- If it has "udlite" in the path, it's UDLite.
- If it's inside a directory that has a udlite-app.js, and that directory doesn't also have an app.js, it's UDLite. The reason for the app.js check is that we have e.g. auth/udlite-app.js, which is not actually a UDLite app, but rather just enabling us to load the UDHeavy signup/login content inside UDLite AjaxModal.
- If it's inside a directory that has a udlite.md file, it's UDLite. This is to handle edge cases, e.g. subscription-browse/components is UDLite, but I can't think of an easy way to understand that without explicitly marking it as such.

Our lesshint linters can use this helper like so:

```
const {isUDLiteFile} = require('eslint-plugin-udemy/helpers/is-udlite-file');
```

##### *JIRA:*
None

##### *What did you test:*
I made the changes manually in website-django and ran `yarn run lint` and `yarn run lesshint`.

##### *What dashboards will you be monitoring:*
None
