### PR TITLE
ETSS-581 Update no-hardcoded-cdns rule for new cdn path

### DIFF
--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -229,12 +229,12 @@ module.exports = {
             'error',
             [
                 {
-                    cdn: 'udemy-images.udemy.com',
-                    fixWith: 'udLink.toS3Images()',
+                    cdn: 's.udemycdn.com',
+                    fixWith: 'udLink.toStorageStaticAsset()',
                 },
                 {
-                    cdn: 's3.amazonaws.com/udemy-images',
-                    fixWith: 'udLink.toS3Images()',
+                    cdn: 'udemy-prod-static-assets.s3.amazonaws.com',
+                    fixWith: 'udLink.toStorageStaticAsset()',
                 },
             ],
         ],

--- a/packages/eslint-config-udemy-website/index.js
+++ b/packages/eslint-config-udemy-website/index.js
@@ -233,7 +233,7 @@ module.exports = {
                     fixWith: 'udLink.toStorageStaticAsset()',
                 },
                 {
-                    cdn: 'udemy-prod-static-assets.s3.amazonaws.com',
+                    cdn: 'udemy-prod-static-assets',
                     fixWith: 'udLink.toStorageStaticAsset()',
                 },
             ],

--- a/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/README.md
+++ b/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/README.md
@@ -11,8 +11,8 @@ Assuming the following configuration:
 ```js
 'udemy/no-hardcoded-cdns': ['error', [
     {
-        cdn: 'udemy-images.udemy.com',
-        fixWith: 'udLink.toS3Images()',
+        cdn: 's.udemycdn.com',
+        fixWith: 'udLink.toStorageStaticAsset()',
     },
 ]]
 ```
@@ -20,16 +20,16 @@ Assuming the following configuration:
 The following would error:
 
 ```js 
-'https://udemy-images.udemy.com/user/123/abc.png'
-`https://udemy-images.udemy.com/user/${user.id}/abc.png`
+'https://s.udemycdn.com/partner-logos/logo.svg'
+`https://s.udemycdn.com/partner-logos/${logo.img}`
 ```
 
 The following would not error:
 
 ```js
 // This outsmarts the rule, but please don't do this!
-['https://udemy-images', 'udemy', 'com'].join('.') + '/user/123/abc.png'
+['https://s', 'udemycdn', 'com'].join('.') + '/partner-logos/logo.svg'
 
 // This is the correct way.
-udLink.toS3Images('user/123/abc.png')
+udLink.toStorageStaticAsset('partner-logos/logo.svg')
 ```

--- a/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/tests.js
+++ b/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/tests.js
@@ -18,7 +18,7 @@ const options = [
             fixWith: 'udLink.toStorageStaticAsset()',
         },
         {
-            cdn: 'udemy-prod-static-assets.s3.amazonaws.com',
+            cdn: 'udemy-prod-static-assets',
             fixWith: 'udLink.toStorageStaticAsset()',
         },
     ],
@@ -66,7 +66,17 @@ ruleTester.run('no-hardcoded-cdns', rule, {
             errors: [
                 {
                     message:
-                        'Please do not hardcode the CDN udemy-prod-static-assets.s3.amazonaws.com. Instead, build the url with udLink.toStorageStaticAsset().',
+                        'Please do not hardcode the CDN udemy-prod-static-assets. Instead, build the url with udLink.toStorageStaticAsset().',
+                },
+            ],
+            options,
+        },
+        {
+            code: "'https://s3.amazonaws.com/udemy-prod-static-assets/partner-logos/logo.svg'",
+            errors: [
+                {
+                    message:
+                        'Please do not hardcode the CDN udemy-prod-static-assets. Instead, build the url with udLink.toStorageStaticAsset().',
                 },
             ],
             options,

--- a/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/tests.js
+++ b/packages/eslint-plugin-udemy/rules/no-hardcoded-cdns/tests.js
@@ -14,8 +14,12 @@ const ruleTester = new RuleTester({
 const options = [
     [
         {
-            cdn: 'udemy-images.udemy.com',
-            fixWith: 'udLink.toS3Images()',
+            cdn: 's.udemycdn.com',
+            fixWith: 'udLink.toStorageStaticAsset()',
+        },
+        {
+            cdn: 'udemy-prod-static-assets.s3.amazonaws.com',
+            fixWith: 'udLink.toStorageStaticAsset()',
         },
     ],
 ];
@@ -23,32 +27,46 @@ const options = [
 ruleTester.run('no-hardcoded-cdns', rule, {
     valid: [
         {
-            code: "udLink.toS3Images('user/123/foo.png')",
+            code: "udLink.toStorageStaticAsset('partner-logos/logo.svg')",
             options,
         },
         {
-            code: '// We used to use udemy-images.udemy.com for S3 images.',
+            code: '// s.udemycdn.com is the domain for our static assets',
+            options,
+        },
+        {
+            code: '// they live in an S3 bucket called udemy-prod-static-assets',
             options,
         },
     ],
     invalid: [
         {
-            code: "'https://udemy-images.udemy.com/user/123/foo.png'",
+            code: "'https://s.udemycdn.com/partner-logos/logo.svg'",
             errors: [
                 {
                     message:
-                        'Please do not hardcode the CDN udemy-images.udemy.com. Instead, build the url with udLink.toS3Images().',
+                        'Please do not hardcode the CDN s.udemycdn.com. Instead, build the url with udLink.toStorageStaticAsset().',
                 },
             ],
             options,
         },
         {
             // eslint-disable-next-line no-template-curly-in-string
-            code: '`https://udemy-images.udemy.com/user/${user.id}/foo.png`',
+            code: '`https://s.udemycdn.com/partner-logos/${logo.img}`',
             errors: [
                 {
                     message:
-                        'Please do not hardcode the CDN udemy-images.udemy.com. Instead, build the url with udLink.toS3Images().',
+                        'Please do not hardcode the CDN s.udemycdn.com. Instead, build the url with udLink.toStorageStaticAsset().',
+                },
+            ],
+            options,
+        },
+        {
+            code: "'https://udemy-prod-static-assets.s3.amazonaws.com/partner-logos/logo.svg'",
+            errors: [
+                {
+                    message:
+                        'Please do not hardcode the CDN udemy-prod-static-assets.s3.amazonaws.com. Instead, build the url with udLink.toStorageStaticAsset().',
                 },
             ],
             options,


### PR DESCRIPTION
##### *To:*
@udemy/web-frontend cc @udemy/media-team 

##### *What:*
Update the `no-hardcoded-cdns` eslint rule. `toS3Images` has been renamed to `toStorageStaticAsset`, it now generates a url with a path like `https://s.udemycdn.com/path.jpg` which points to an S3 bucket `udemy-prod-static-assets`.

We no longer use the `udemy-images` bucket for our static assets.

##### *JIRA:*
[ETSS-581](https://udemyjira.atlassian.net/browse/ETSS-581)

##### *What did you test:*
Just yarn test

##### *What dashboards will you be monitoring:*
?
