### PR TITLE
Assume all files are udlite unless indicated otherwise (DST-197)

### DIFF
--- a/packages/eslint-plugin-udemy/helpers/is-udlite-file.js
+++ b/packages/eslint-plugin-udemy/helpers/is-udlite-file.js
@@ -26,10 +26,8 @@ function findUDLiteDirs(dir) {
     const udliteDirs = [];
     const children = fs.readdirSync(dir);
     const childrenSet = new Set(children);
-    if (childrenSet.has('udlite-app.js') && !childrenSet.has('app.js')) {
-        udliteDirs.push(dir);
-    } else if (childrenSet.has('udlite.md')) {
-        udliteDirs.push(dir);
+    if (childrenSet.has('udheavy.md')) {
+        return udliteDirs;
     }
 
     children.forEach(child => {


### PR DESCRIPTION
##### *To:*
@udemy/web-frontend cc @udemy/design-system 

##### *What:*
Currently apps have to be explicitly marked in order for udlite linting to apply. But now we've breached 50% udlite usage, it would be better to explicitly mark the udheavy directories, such that the default position is that all apps are udlite, and we'll gradually reduce udheavy apps.